### PR TITLE
refactor: use separate folders for keepers, keys and modules

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -144,7 +144,7 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 
 	// Iterate through validators by power descending, reset bond heights, and
 	// update bond intra-tx counters.
-	store := ctx.KVStore(app.keys[stakingtypes.StoreKey])
+	store := ctx.KVStore(app.AppKeepers.GetKVStoreKey()[stakingtypes.StoreKey])
 	iter := sdk.KVStoreReversePrefixIterator(store, stakingtypes.ValidatorsKey)
 	counter := int16(0)
 

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -1,0 +1,495 @@
+package keepers
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/codec"
+	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authkeeper "github.com/cosmos/cosmos-sdk/x/auth/keeper"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	capabilitykeeper "github.com/cosmos/cosmos-sdk/x/capability/keeper"
+	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
+	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
+	"github.com/cosmos/cosmos-sdk/x/distribution"
+	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	evidencekeeper "github.com/cosmos/cosmos-sdk/x/evidence/keeper"
+	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
+	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/cosmos/cosmos-sdk/x/params"
+	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	paramproposal "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
+	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/cosmos/cosmos-sdk/x/upgrade"
+	upgradekeeper "github.com/cosmos/cosmos-sdk/x/upgrade/keeper"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	ica "github.com/cosmos/ibc-go/v4/modules/apps/27-interchain-accounts"
+	icacontroller "github.com/cosmos/ibc-go/v4/modules/apps/27-interchain-accounts/controller"
+	icacontrollerkeeper "github.com/cosmos/ibc-go/v4/modules/apps/27-interchain-accounts/controller/keeper"
+	icacontrollertypes "github.com/cosmos/ibc-go/v4/modules/apps/27-interchain-accounts/controller/types"
+	ibctransfertypes "github.com/cosmos/ibc-go/v4/modules/apps/transfer/types"
+	ibcclient "github.com/cosmos/ibc-go/v4/modules/core/02-client"
+	ibcclienttypes "github.com/cosmos/ibc-go/v4/modules/core/02-client/types"
+	ibcporttypes "github.com/cosmos/ibc-go/v4/modules/core/05-port/types"
+	ibchost "github.com/cosmos/ibc-go/v4/modules/core/24-host"
+	ibckeeper "github.com/cosmos/ibc-go/v4/modules/core/keeper"
+
+	"github.com/tendermint/spm/cosmoscmd"
+
+	"github.com/Nolus-Protocol/nolus-core/wasmbinding"
+	mintkeeper "github.com/Nolus-Protocol/nolus-core/x/mint/keeper"
+	minttypes "github.com/Nolus-Protocol/nolus-core/x/mint/types"
+	"github.com/Nolus-Protocol/nolus-core/x/tax"
+	taxmodulekeeper "github.com/Nolus-Protocol/nolus-core/x/tax/keeper"
+	taxmoduletypes "github.com/Nolus-Protocol/nolus-core/x/tax/types"
+
+	"github.com/CosmWasm/wasmd/x/wasm"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+
+	"github.com/neutron-org/neutron/x/contractmanager"
+	contractmanagermodulekeeper "github.com/neutron-org/neutron/x/contractmanager/keeper"
+	contractmanagermoduletypes "github.com/neutron-org/neutron/x/contractmanager/types"
+	"github.com/neutron-org/neutron/x/feerefunder"
+	feekeeper "github.com/neutron-org/neutron/x/feerefunder/keeper"
+	feetypes "github.com/neutron-org/neutron/x/feerefunder/types"
+	"github.com/neutron-org/neutron/x/interchainqueries"
+	interchainquerieskeeper "github.com/neutron-org/neutron/x/interchainqueries/keeper"
+	interchainqueriestypes "github.com/neutron-org/neutron/x/interchainqueries/types"
+	"github.com/neutron-org/neutron/x/interchaintxs"
+	interchaintxskeeper "github.com/neutron-org/neutron/x/interchaintxs/keeper"
+	interchaintxstypes "github.com/neutron-org/neutron/x/interchaintxs/types"
+	transferSudo "github.com/neutron-org/neutron/x/transfer"
+	wrapkeeper "github.com/neutron-org/neutron/x/transfer/keeper"
+)
+
+var (
+	// WasmProposalsEnabled enables all x/wasm proposals when it's value is "true"
+	// and EnableSpecificWasmProposals is empty. Otherwise, all x/wasm proposals
+	// are disabled.
+	WasmProposalsEnabled = "true"
+
+	// EnableSpecificWasmProposals, if set, must be comma-separated list of values
+	// that are all a subset of "EnableAllProposals", which takes precedence over
+	// WasmProposalsEnabled.
+	//
+	// See: https://github.com/CosmWasm/wasmd/blob/02a54d33ff2c064f3539ae12d75d027d9c665f05/x/wasm/internal/types/proposal.go#L28-L34
+	EnableSpecificWasmProposals = ""
+
+	// EmptyWasmOpts defines a type alias for a list of wasm options.
+	EmptyWasmOpts []wasm.Option
+)
+
+var (
+	// If EnabledSpecificProposals is "", and this is "true", then enable all x/wasm proposals.
+	// If EnabledSpecificProposals is "", and this is not "true", then disable all x/wasm proposals.
+	ProposalsEnabled = "true"
+	// If set to non-empty string it must be comma-separated list of values that are all a subset
+	// of "EnableAllProposals" (takes precedence over ProposalsEnabled)
+	// https://github.com/CosmWasm/wasmd/blob/02a54d33ff2c064f3539ae12d75d027d9c665f05/x/wasm/internal/types/proposal.go#L28-L34
+	EnableSpecificProposals = ""
+)
+
+// GetWasmEnabledProposals parses the WasmProposalsEnabled and
+// EnableSpecificWasmProposals values to produce a list of enabled proposals to
+// pass into the application.
+func GetWasmEnabledProposals() []wasm.ProposalType {
+	if EnableSpecificWasmProposals == "" {
+		if WasmProposalsEnabled == "true" {
+			return wasm.EnableAllProposals
+		}
+
+		return wasm.DisableAllProposals
+	}
+
+	chunks := strings.Split(EnableSpecificWasmProposals, ",")
+
+	proposals, err := wasm.ConvertToProposals(chunks)
+	if err != nil {
+		panic(err)
+	}
+
+	return proposals
+}
+
+type AppKeepers struct {
+	// keys to access the substores
+	keys    map[string]*sdk.KVStoreKey
+	tkeys   map[string]*sdk.TransientStoreKey
+	memKeys map[string]*sdk.MemoryStoreKey
+
+	// keepers
+	AccountKeeper       authkeeper.AccountKeeper
+	BankKeeper          bankkeeper.Keeper
+	CapabilityKeeper    *capabilitykeeper.Keeper
+	StakingKeeper       stakingkeeper.Keeper
+	SlashingKeeper      slashingkeeper.Keeper
+	MintKeeper          mintkeeper.Keeper
+	DistrKeeper         distrkeeper.Keeper
+	GovKeeper           govkeeper.Keeper
+	CrisisKeeper        crisiskeeper.Keeper
+	UpgradeKeeper       upgradekeeper.Keeper
+	ParamsKeeper        paramskeeper.Keeper
+	IBCKeeper           *ibckeeper.Keeper // IBC Keeper must be a pointer in the app, so we can SetRouter on it correctly
+	ICAControllerKeeper icacontrollerkeeper.Keeper
+	EvidenceKeeper      evidencekeeper.Keeper
+	TransferKeeper      wrapkeeper.KeeperTransferWrapper
+	FeeKeeper           *feekeeper.Keeper
+
+	// make scoped keepers public for test purposes
+	ScopedIBCKeeper           capabilitykeeper.ScopedKeeper
+	ScopedTransferKeeper      capabilitykeeper.ScopedKeeper
+	ScopedInterchainTxsKeeper capabilitykeeper.ScopedKeeper
+	ScopedWasmKeeper          capabilitykeeper.ScopedKeeper
+	ScopedICAControllerKeeper capabilitykeeper.ScopedKeeper
+
+	TaxKeeper taxmodulekeeper.Keeper
+
+	InterchainTxsKeeper     interchaintxskeeper.Keeper
+	InterchainQueriesKeeper interchainquerieskeeper.Keeper
+	ContractManagerKeeper   contractmanagermodulekeeper.Keeper
+
+	WasmKeeper wasm.Keeper
+	WasmConfig wasmtypes.WasmConfig
+
+	// Modules
+	ContractManagerModule   contractmanager.AppModule
+	InterchainTxsModule     interchaintxs.AppModule
+	InterchainQueriesModule interchainqueries.AppModule
+	TransferModule          transferSudo.AppModule
+	FeeRefunderModule       feerefunder.AppModule
+	TaxModule               tax.AppModule
+	IcaModule               ica.AppModule
+}
+
+func NewAppKeeper(
+	appCodec codec.Codec,
+	bApp *baseapp.BaseApp,
+	encodingConfig cosmoscmd.EncodingConfig,
+	maccPerms map[string][]string,
+	blockedAddress map[string]bool,
+	skipUpgradeHeights map[int64]bool,
+	homePath string,
+	invCheckPeriod uint,
+	appOpts servertypes.AppOptions,
+) AppKeepers {
+	appKeepers := AppKeepers{}
+
+	// Set keys KVStoreKey, TransientStoreKey, MemoryStoreKey
+	appKeepers.GenerateKeys()
+
+	appKeepers.ParamsKeeper = initParamsKeeper(
+		appCodec,
+		encodingConfig.Amino,
+		appKeepers.keys[paramstypes.StoreKey],
+		appKeepers.tkeys[paramstypes.TStoreKey],
+	)
+
+	// set the BaseApp's parameter store
+	bApp.SetParamStore(
+		appKeepers.ParamsKeeper.Subspace(baseapp.Paramspace).WithKeyTable(paramskeeper.ConsensusParamsKeyTable()),
+	)
+
+	// add capability keeper and ScopeToModule for ibc module
+	appKeepers.CapabilityKeeper = capabilitykeeper.NewKeeper(
+		appCodec, appKeepers.keys[capabilitytypes.StoreKey], appKeepers.memKeys[capabilitytypes.MemStoreKey],
+	)
+
+	// grant capabilities for the ibc and ibc-transfer modules
+	appKeepers.ScopedIBCKeeper = appKeepers.CapabilityKeeper.ScopeToModule(ibchost.ModuleName)
+	appKeepers.ScopedTransferKeeper = appKeepers.CapabilityKeeper.ScopeToModule(ibctransfertypes.ModuleName)
+	appKeepers.ScopedInterchainTxsKeeper = appKeepers.CapabilityKeeper.ScopeToModule(interchaintxstypes.ModuleName)
+	appKeepers.ScopedICAControllerKeeper = appKeepers.CapabilityKeeper.ScopeToModule(icacontrollertypes.SubModuleName)
+	appKeepers.ScopedWasmKeeper = appKeepers.CapabilityKeeper.ScopeToModule(wasm.ModuleName)
+
+	// seal capabilities after scoping modules
+	appKeepers.CapabilityKeeper.Seal()
+
+	appKeepers.CrisisKeeper = crisiskeeper.NewKeeper(
+		appKeepers.GetSubspace(crisistypes.ModuleName),
+		invCheckPeriod,
+		appKeepers.BankKeeper,
+		authtypes.FeeCollectorName,
+	)
+
+	// Add normal keepers
+	// add keepers
+	appKeepers.AccountKeeper = authkeeper.NewAccountKeeper(
+		appCodec,
+		appKeepers.keys[authtypes.StoreKey],
+		appKeepers.GetSubspace(authtypes.ModuleName),
+		authtypes.ProtoBaseAccount,
+		maccPerms,
+	)
+	appKeepers.BankKeeper = bankkeeper.NewBaseKeeper(
+		appCodec,
+		appKeepers.keys[banktypes.StoreKey],
+		appKeepers.AccountKeeper,
+		appKeepers.GetSubspace(banktypes.ModuleName),
+		blockedAddress,
+	)
+	stakingKeeper := stakingkeeper.NewKeeper(
+		appCodec,
+		appKeepers.keys[stakingtypes.StoreKey],
+		appKeepers.AccountKeeper,
+		appKeepers.BankKeeper,
+		appKeepers.GetSubspace(stakingtypes.ModuleName),
+	)
+	appKeepers.MintKeeper = mintkeeper.NewKeeper(
+		appCodec,
+		appKeepers.keys[minttypes.StoreKey],
+		appKeepers.GetSubspace(minttypes.ModuleName),
+		appKeepers.AccountKeeper,
+		appKeepers.BankKeeper,
+		authtypes.FeeCollectorName,
+	)
+	appKeepers.DistrKeeper = distrkeeper.NewKeeper(
+		appCodec,
+		appKeepers.keys[distrtypes.StoreKey],
+		appKeepers.GetSubspace(distrtypes.ModuleName),
+		appKeepers.AccountKeeper,
+		appKeepers.BankKeeper,
+		&stakingKeeper,
+		authtypes.FeeCollectorName,
+		blockedAddress,
+	)
+	appKeepers.SlashingKeeper = slashingkeeper.NewKeeper(
+		appCodec,
+		appKeepers.keys[slashingtypes.StoreKey],
+		&stakingKeeper,
+		appKeepers.GetSubspace(slashingtypes.ModuleName),
+	)
+
+	// register the staking hooks
+	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
+	appKeepers.StakingKeeper = *stakingKeeper.SetHooks(
+		stakingtypes.NewMultiStakingHooks(
+			appKeepers.DistrKeeper.Hooks(),
+			appKeepers.SlashingKeeper.Hooks()),
+	)
+
+	// UpgradeKeeper must be created before IBCKeeper
+	appKeepers.UpgradeKeeper = upgradekeeper.NewKeeper(
+		skipUpgradeHeights,
+		appKeepers.keys[upgradetypes.StoreKey],
+		appCodec,
+		homePath,
+		bApp,
+	)
+
+	// UpgradeKeeper must be created before IBCKeeper
+	appKeepers.IBCKeeper = ibckeeper.NewKeeper(
+		appCodec,
+		appKeepers.keys[ibchost.StoreKey],
+		appKeepers.GetSubspace(ibchost.ModuleName),
+		appKeepers.StakingKeeper,
+		appKeepers.UpgradeKeeper,
+		appKeepers.ScopedIBCKeeper,
+	)
+
+	appKeepers.ContractManagerKeeper = *contractmanagermodulekeeper.NewKeeper(
+		appCodec,
+		appKeepers.keys[contractmanagermoduletypes.StoreKey],
+		appKeepers.keys[contractmanagermoduletypes.MemStoreKey],
+		appKeepers.GetSubspace(contractmanagermoduletypes.ModuleName),
+		&appKeepers.WasmKeeper,
+	)
+	appKeepers.ContractManagerModule = contractmanager.NewAppModule(appCodec, appKeepers.ContractManagerKeeper)
+
+	appKeepers.FeeKeeper = feekeeper.NewKeeper(
+		appCodec,
+		appKeepers.keys[feetypes.StoreKey],
+		appKeepers.memKeys[feetypes.MemStoreKey],
+		appKeepers.GetSubspace(feetypes.ModuleName),
+		appKeepers.IBCKeeper.ChannelKeeper,
+		appKeepers.BankKeeper,
+	)
+	appKeepers.FeeRefunderModule = feerefunder.NewAppModule(appCodec, *appKeepers.FeeKeeper, appKeepers.AccountKeeper, appKeepers.BankKeeper)
+
+	appKeepers.TransferKeeper = wrapkeeper.NewKeeper(
+		appCodec,
+		appKeepers.keys[ibctransfertypes.StoreKey],
+		appKeepers.GetSubspace(ibctransfertypes.ModuleName),
+		appKeepers.IBCKeeper.ChannelKeeper,
+		appKeepers.IBCKeeper.ChannelKeeper,
+		&appKeepers.IBCKeeper.PortKeeper,
+		appKeepers.AccountKeeper,
+		appKeepers.BankKeeper,
+		appKeepers.ScopedTransferKeeper,
+		appKeepers.FeeKeeper,
+		appKeepers.ContractManagerKeeper,
+	)
+	appKeepers.TransferModule = transferSudo.NewAppModule(appKeepers.TransferKeeper)
+
+	// Create evidence Keeper for to register the IBC light client misbehaviour evidence route
+	evidenceKeeper := evidencekeeper.NewKeeper(
+		appCodec, appKeepers.keys[evidencetypes.StoreKey], &appKeepers.StakingKeeper, appKeepers.SlashingKeeper,
+	)
+	// If evidence needs to be handled for the app, set routes in router here and seal
+	appKeepers.EvidenceKeeper = *evidenceKeeper
+
+	// register the proposal types
+	govRouter := govtypes.NewRouter()
+	govRouter.AddRoute(govtypes.RouterKey, govtypes.ProposalHandler).
+		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(appKeepers.ParamsKeeper)).
+		AddRoute(ibcclienttypes.RouterKey, ibcclient.NewClientProposalHandler(appKeepers.IBCKeeper.ClientKeeper)).
+		AddRoute(upgradetypes.RouterKey, upgrade.NewSoftwareUpgradeProposalHandler(appKeepers.UpgradeKeeper)).
+		AddRoute(ibchost.RouterKey, ibcclient.NewClientProposalHandler(appKeepers.IBCKeeper.ClientKeeper)).
+		AddRoute(distrtypes.RouterKey, distribution.NewCommunityPoolSpendProposalHandler(appKeepers.DistrKeeper))
+
+	appKeepers.ICAControllerKeeper = icacontrollerkeeper.NewKeeper(
+		appCodec,
+		appKeepers.keys[icacontrollertypes.StoreKey],
+		appKeepers.GetSubspace(icacontrollertypes.SubModuleName),
+		appKeepers.IBCKeeper.ChannelKeeper,
+		appKeepers.IBCKeeper.ChannelKeeper,
+		&appKeepers.IBCKeeper.PortKeeper,
+		appKeepers.ScopedICAControllerKeeper,
+		bApp.MsgServiceRouter(),
+	)
+	appKeepers.IcaModule = ica.NewAppModule(&appKeepers.ICAControllerKeeper, nil)
+
+	appKeepers.InterchainQueriesKeeper = *interchainquerieskeeper.NewKeeper(
+		appCodec,
+		appKeepers.keys[interchainqueriestypes.StoreKey],
+		appKeepers.keys[interchainqueriestypes.MemStoreKey],
+		appKeepers.GetSubspace(interchainqueriestypes.ModuleName),
+		appKeepers.IBCKeeper,
+		appKeepers.BankKeeper,
+		appKeepers.ContractManagerKeeper,
+		interchainquerieskeeper.Verifier{},
+		interchainquerieskeeper.TransactionVerifier{},
+	)
+	appKeepers.InterchainQueriesModule = interchainqueries.NewAppModule(appCodec, appKeepers.InterchainQueriesKeeper, appKeepers.AccountKeeper, appKeepers.BankKeeper)
+
+	appKeepers.InterchainTxsKeeper = *interchaintxskeeper.NewKeeper(
+		appCodec,
+		appKeepers.keys[interchaintxstypes.StoreKey],
+		appKeepers.memKeys[interchaintxstypes.MemStoreKey],
+		appKeepers.GetSubspace(interchaintxstypes.ModuleName),
+		appKeepers.IBCKeeper.ChannelKeeper,
+		appKeepers.ICAControllerKeeper,
+		appKeepers.ScopedInterchainTxsKeeper,
+		appKeepers.ContractManagerKeeper,
+		appKeepers.FeeKeeper,
+	)
+	appKeepers.InterchainTxsModule = interchaintxs.NewAppModule(appCodec, appKeepers.InterchainTxsKeeper, appKeepers.AccountKeeper, appKeepers.BankKeeper)
+
+	wasmDir := filepath.Join(homePath, "wasm")
+	wasmConfig, err := wasm.ReadWasmConfig(appOpts)
+	if err != nil {
+		panic("error while reading wasm config: " + err.Error())
+	}
+	appKeepers.WasmConfig = wasmConfig
+
+	// Set the maximum wasm code size to 1500*1024 (1.5MB). This is the maximum size of a wasm bytecode that can be uploaded on genesis.
+	// Starting with wasmd v0.30.0, this variable will also be used to limit the maximum size of a wasm bytecode that can be uploaded via governance.
+	wasmtypes.MaxWasmSize = 1500 * 1024
+	var wasmOpts []wasm.Option
+	// The last arguments can contain custom message handlers, and custom query handlers,
+	// if we want to allow any custom callbacks
+	supportedFeatures := "iterator,staking,stargate,migrate,upgrade,neutron,cosmwasm_1_1"
+	wasmOpts = append(wasmbinding.RegisterCustomPlugins(&appKeepers.InterchainTxsKeeper, &appKeepers.InterchainQueriesKeeper, appKeepers.TransferKeeper), wasmOpts...)
+	appKeepers.WasmKeeper = wasm.NewKeeper(
+		appCodec,
+		appKeepers.keys[wasm.StoreKey],
+		appKeepers.GetSubspace(wasm.ModuleName),
+		appKeepers.AccountKeeper,
+		appKeepers.BankKeeper,
+		appKeepers.StakingKeeper,
+		appKeepers.DistrKeeper,
+		appKeepers.IBCKeeper.ChannelKeeper,
+		&appKeepers.IBCKeeper.PortKeeper,
+		appKeepers.ScopedWasmKeeper,
+		appKeepers.TransferKeeper,
+		bApp.MsgServiceRouter(),
+		bApp.GRPCQueryRouter(),
+		wasmDir,
+		wasmConfig,
+		supportedFeatures,
+		wasmOpts...,
+	)
+
+	// The gov proposal types can be individually enabled
+	if len(GetWasmEnabledProposals()) != 0 {
+		govRouter.AddRoute(wasm.RouterKey, wasm.NewWasmProposalHandler(appKeepers.WasmKeeper, GetWasmEnabledProposals()))
+	}
+
+	appKeepers.GovKeeper = govkeeper.NewKeeper(
+		appCodec,
+		appKeepers.keys[govtypes.StoreKey],
+		appKeepers.GetSubspace(govtypes.ModuleName),
+		appKeepers.AccountKeeper,
+		appKeepers.BankKeeper,
+		appKeepers.StakingKeeper,
+		govRouter,
+	)
+
+	appKeepers.TaxKeeper = *taxmodulekeeper.NewKeeper(
+		appCodec,
+		appKeepers.keys[taxmoduletypes.StoreKey],
+		appKeepers.keys[taxmoduletypes.MemStoreKey],
+		appKeepers.GetSubspace(taxmoduletypes.ModuleName),
+	)
+	appKeepers.TaxModule = tax.NewAppModule(appCodec, appKeepers.TaxKeeper, appKeepers.AccountKeeper, appKeepers.BankKeeper)
+
+	transferIBCModule := transferSudo.NewIBCModule(appKeepers.TransferKeeper)
+
+	var icaControllerStack ibcporttypes.IBCModule
+
+	icaControllerStack = interchaintxs.NewIBCModule(appKeepers.InterchainTxsKeeper)
+	icaControllerStack = icacontroller.NewIBCMiddleware(icaControllerStack, appKeepers.ICAControllerKeeper)
+
+	// Create static IBC router, add transfer route, then set and seal it
+	ibcRouter := ibcporttypes.NewRouter()
+	ibcRouter.AddRoute(icacontrollertypes.SubModuleName, icaControllerStack).
+		AddRoute(ibctransfertypes.ModuleName, transferIBCModule).
+		AddRoute(interchaintxstypes.ModuleName, icaControllerStack).
+		AddRoute(wasm.ModuleName, wasm.NewIBCHandler(appKeepers.WasmKeeper, appKeepers.IBCKeeper.ChannelKeeper, appKeepers.IBCKeeper.ChannelKeeper))
+	appKeepers.IBCKeeper.SetRouter(ibcRouter)
+
+	return appKeepers
+}
+
+// GetSubspace returns a param subspace for a given module name.
+func (appKeepers *AppKeepers) GetSubspace(moduleName string) paramstypes.Subspace {
+	subspace, _ := appKeepers.ParamsKeeper.GetSubspace(moduleName)
+	return subspace
+}
+
+// initParamsKeeper init params keeper and its subspaces.
+func initParamsKeeper(
+	appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino, key, tkey sdk.StoreKey,
+) paramskeeper.Keeper {
+	paramsKeeper := paramskeeper.NewKeeper(appCodec, legacyAmino, key, tkey)
+
+	paramsKeeper.Subspace(taxmoduletypes.ModuleName)
+	paramsKeeper.Subspace(authtypes.ModuleName)
+	paramsKeeper.Subspace(banktypes.ModuleName)
+	paramsKeeper.Subspace(stakingtypes.ModuleName)
+	paramsKeeper.Subspace(minttypes.ModuleName)
+	paramsKeeper.Subspace(distrtypes.ModuleName)
+	paramsKeeper.Subspace(slashingtypes.ModuleName)
+	paramsKeeper.Subspace(crisistypes.ModuleName)
+	paramsKeeper.Subspace(ibctransfertypes.ModuleName)
+	paramsKeeper.Subspace(ibchost.ModuleName)
+	paramsKeeper.Subspace(wasm.ModuleName)
+	paramsKeeper.Subspace(govtypes.ModuleName).WithKeyTable(govtypes.ParamKeyTable())
+	paramsKeeper.Subspace(icacontrollertypes.SubModuleName)
+	paramsKeeper.Subspace(feetypes.ModuleName)
+	paramsKeeper.Subspace(interchaintxstypes.ModuleName)
+	paramsKeeper.Subspace(interchainqueriestypes.ModuleName)
+
+	return paramsKeeper
+}

--- a/app/keepers/keys.go
+++ b/app/keepers/keys.go
@@ -1,0 +1,82 @@
+package keepers
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+
+	icacontrollertypes "github.com/cosmos/ibc-go/v4/modules/apps/27-interchain-accounts/controller/types"
+	ibctransfertypes "github.com/cosmos/ibc-go/v4/modules/apps/transfer/types"
+	ibchost "github.com/cosmos/ibc-go/v4/modules/core/24-host"
+
+	minttypes "github.com/Nolus-Protocol/nolus-core/x/mint/types"
+	taxmoduletypes "github.com/Nolus-Protocol/nolus-core/x/tax/types"
+
+	"github.com/CosmWasm/wasmd/x/wasm"
+
+	contractmanagermoduletypes "github.com/neutron-org/neutron/x/contractmanager/types"
+	feerefundertypes "github.com/neutron-org/neutron/x/feerefunder/types"
+	interchainqueriestypes "github.com/neutron-org/neutron/x/interchainqueries/types"
+	interchaintxstypes "github.com/neutron-org/neutron/x/interchaintxs/types"
+)
+
+func (appKeepers *AppKeepers) GenerateKeys() {
+	// Define what keys will be used in the cosmos-sdk key/value store.
+	// Cosmos-SDK modules each have a "key" that allows the application to reference what they've stored on the chain.
+	appKeepers.keys = sdk.NewKVStoreKeys(
+		authtypes.StoreKey, banktypes.StoreKey, stakingtypes.StoreKey,
+		minttypes.StoreKey, distrtypes.StoreKey, slashingtypes.StoreKey,
+		govtypes.StoreKey, paramstypes.StoreKey, ibchost.StoreKey,
+		upgradetypes.StoreKey, evidencetypes.StoreKey, ibctransfertypes.StoreKey,
+		taxmoduletypes.StoreKey, icacontrollertypes.StoreKey, capabilitytypes.StoreKey,
+		interchainqueriestypes.StoreKey, contractmanagermoduletypes.StoreKey, interchaintxstypes.StoreKey,
+		wasm.StoreKey, feerefundertypes.StoreKey,
+	)
+
+	// Define transient store keys
+	appKeepers.tkeys = sdk.NewTransientStoreKeys(paramstypes.TStoreKey)
+
+	// MemKeys are for information that is stored only in RAM.
+	appKeepers.memKeys = sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey, feerefundertypes.MemStoreKey)
+}
+
+func (appKeepers *AppKeepers) GetKVStoreKey() map[string]*sdk.KVStoreKey {
+	return appKeepers.keys
+}
+
+func (appKeepers *AppKeepers) GetTransientStoreKey() map[string]*sdk.TransientStoreKey {
+	return appKeepers.tkeys
+}
+
+func (appKeepers *AppKeepers) GetMemoryStoreKey() map[string]*sdk.MemoryStoreKey {
+	return appKeepers.memKeys
+}
+
+// GetKey returns the KVStoreKey for the provided store key.
+//
+// NOTE: This is solely to be used for testing purposes.
+func (appKeepers *AppKeepers) GetKey(storeKey string) *sdk.KVStoreKey {
+	return appKeepers.keys[storeKey]
+}
+
+// GetTKey returns the TransientStoreKey for the provided store key.
+//
+// NOTE: This is solely to be used for testing purposes.
+func (appKeepers *AppKeepers) GetTKey(storeKey string) *sdk.TransientStoreKey {
+	return appKeepers.tkeys[storeKey]
+}
+
+// GetMemKey returns the MemStoreKey for the provided mem key.
+//
+// NOTE: This is solely used for testing purposes.
+func (appKeepers *AppKeepers) GetMemKey(storeKey string) *sdk.MemoryStoreKey {
+	return appKeepers.memKeys[storeKey]
+}

--- a/app/modules.go
+++ b/app/modules.go
@@ -1,0 +1,304 @@
+package app
+
+import (
+	"github.com/cosmos/cosmos-sdk/types/module"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	authsims "github.com/cosmos/cosmos-sdk/x/auth/simulation"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/vesting"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/cosmos/cosmos-sdk/x/capability"
+	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+	"github.com/cosmos/cosmos-sdk/x/crisis"
+	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
+	"github.com/cosmos/cosmos-sdk/x/distribution"
+	distrclient "github.com/cosmos/cosmos-sdk/x/distribution/client"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	"github.com/cosmos/cosmos-sdk/x/evidence"
+	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
+	"github.com/cosmos/cosmos-sdk/x/genutil"
+	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
+	"github.com/cosmos/cosmos-sdk/x/gov"
+	govclient "github.com/cosmos/cosmos-sdk/x/gov/client"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	"github.com/cosmos/cosmos-sdk/x/params"
+	paramsclient "github.com/cosmos/cosmos-sdk/x/params/client"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	"github.com/cosmos/cosmos-sdk/x/slashing"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	"github.com/cosmos/cosmos-sdk/x/staking"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/cosmos/cosmos-sdk/x/upgrade"
+	upgradeclient "github.com/cosmos/cosmos-sdk/x/upgrade/client"
+	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	"github.com/tendermint/spm/cosmoscmd"
+
+	ica "github.com/cosmos/ibc-go/v4/modules/apps/27-interchain-accounts"
+	icatypes "github.com/cosmos/ibc-go/v4/modules/apps/27-interchain-accounts/types"
+	ibctransfertypes "github.com/cosmos/ibc-go/v4/modules/apps/transfer/types"
+	ibc "github.com/cosmos/ibc-go/v4/modules/core"
+	ibcclientclient "github.com/cosmos/ibc-go/v4/modules/core/02-client/client"
+	ibchost "github.com/cosmos/ibc-go/v4/modules/core/24-host"
+
+	"github.com/Nolus-Protocol/nolus-core/x/mint"
+	minttypes "github.com/Nolus-Protocol/nolus-core/x/mint/types"
+	"github.com/Nolus-Protocol/nolus-core/x/tax"
+	taxmoduletypes "github.com/Nolus-Protocol/nolus-core/x/tax/types"
+
+	"github.com/CosmWasm/wasmd/x/wasm"
+	wasmclient "github.com/CosmWasm/wasmd/x/wasm/client"
+
+	"github.com/neutron-org/neutron/x/contractmanager"
+	contractmanagermoduletypes "github.com/neutron-org/neutron/x/contractmanager/types"
+	"github.com/neutron-org/neutron/x/feerefunder"
+	feetypes "github.com/neutron-org/neutron/x/feerefunder/types"
+	"github.com/neutron-org/neutron/x/interchainqueries"
+	interchainqueriestypes "github.com/neutron-org/neutron/x/interchainqueries/types"
+	"github.com/neutron-org/neutron/x/interchaintxs"
+	interchaintxstypes "github.com/neutron-org/neutron/x/interchaintxs/types"
+	transferSudo "github.com/neutron-org/neutron/x/transfer"
+)
+
+func getGovProposalHandlers() []govclient.ProposalHandler {
+	var govProposalHandlers []govclient.ProposalHandler
+
+	govProposalHandlers = append(
+		govProposalHandlers,
+		paramsclient.ProposalHandler,
+		distrclient.ProposalHandler,
+		upgradeclient.ProposalHandler,
+		upgradeclient.CancelProposalHandler,
+		ibcclientclient.UpdateClientProposalHandler,
+		ibcclientclient.UpgradeProposalHandler,
+	)
+
+	govProposalHandlers = append(govProposalHandlers, wasmclient.ProposalHandlers...)
+
+	return govProposalHandlers
+}
+
+// module account permissions.
+var maccPerms = map[string][]string{
+	authtypes.FeeCollectorName:        nil,
+	distrtypes.ModuleName:             nil,
+	minttypes.ModuleName:              {authtypes.Minter},
+	stakingtypes.BondedPoolName:       {authtypes.Burner, authtypes.Staking},
+	stakingtypes.NotBondedPoolName:    {authtypes.Burner, authtypes.Staking},
+	govtypes.ModuleName:               {authtypes.Burner},
+	ibctransfertypes.ModuleName:       {authtypes.Minter, authtypes.Burner},
+	wasm.ModuleName:                   {authtypes.Burner},
+	icatypes.ModuleName:               nil,
+	interchainqueriestypes.ModuleName: nil,
+	feetypes.ModuleName:               nil,
+}
+
+// ModuleBasics defines the module BasicManager is in charge of setting up basic,
+// non-dependant module elements, such as codec registration
+// and genesis verification.
+var ModuleBasics = module.NewBasicManager(
+	genutil.AppModuleBasic{},
+	auth.AppModuleBasic{},
+	bank.AppModuleBasic{},
+	capability.AppModuleBasic{},
+	staking.AppModuleBasic{},
+	mint.AppModuleBasic{},
+	distribution.AppModuleBasic{},
+	gov.NewAppModuleBasic(getGovProposalHandlers()...),
+	params.AppModuleBasic{},
+	crisis.AppModuleBasic{},
+	slashing.AppModuleBasic{},
+	ibc.AppModuleBasic{},
+	upgrade.AppModuleBasic{},
+	evidence.AppModuleBasic{},
+	transferSudo.AppModuleBasic{},
+	vesting.AppModuleBasic{},
+	wasm.AppModuleBasic{},
+	tax.AppModuleBasic{},
+	ica.AppModuleBasic{},
+	interchaintxs.AppModuleBasic{},
+	interchainqueries.AppModuleBasic{},
+	feerefunder.AppModuleBasic{},
+	contractmanager.AppModuleBasic{},
+)
+
+func appModules(
+	app *App,
+	encodingConfig cosmoscmd.EncodingConfig,
+	skipGenesisInvariants bool,
+) []module.AppModule {
+	appCodec := encodingConfig.Marshaler
+
+	return []module.AppModule{
+		genutil.NewAppModule(
+			app.AccountKeeper,
+			app.StakingKeeper,
+			app.BaseApp.DeliverTx,
+			encodingConfig.TxConfig,
+		),
+		auth.NewAppModule(appCodec, app.AccountKeeper, nil),
+		vesting.NewAppModule(app.AccountKeeper, app.BankKeeper),
+		bank.NewAppModule(appCodec, app.BankKeeper, app.AccountKeeper),
+		capability.NewAppModule(appCodec, *app.CapabilityKeeper),
+		crisis.NewAppModule(&app.CrisisKeeper, skipGenesisInvariants),
+		gov.NewAppModule(appCodec, app.GovKeeper, app.AccountKeeper, app.BankKeeper),
+		mint.NewAppModule(appCodec, app.MintKeeper, app.AccountKeeper),
+		slashing.NewAppModule(appCodec, app.SlashingKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
+		distribution.NewAppModule(appCodec, app.DistrKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
+		staking.NewAppModule(appCodec, app.StakingKeeper, app.AccountKeeper, app.BankKeeper),
+		upgrade.NewAppModule(app.UpgradeKeeper),
+		wasm.NewAppModule(
+			appCodec, &app.WasmKeeper,
+			app.AccountKeeper, app.BankKeeper,
+		),
+		evidence.NewAppModule(app.EvidenceKeeper),
+		ibc.NewAppModule(app.IBCKeeper),
+		params.NewAppModule(app.ParamsKeeper),
+		app.AppKeepers.TransferModule,
+		app.AppKeepers.TaxModule,
+		app.AppKeepers.IcaModule,
+		app.AppKeepers.InterchainQueriesModule,
+		app.AppKeepers.InterchainTxsModule,
+		app.AppKeepers.FeeRefunderModule,
+		app.AppKeepers.ContractManagerModule,
+	}
+}
+
+// simulationModules returns modules for simulation manager
+// define the order of the modules for deterministic simulations.
+func simulationModules(
+	app *App,
+	encodingConfig cosmoscmd.EncodingConfig,
+	_ bool,
+) []module.AppModuleSimulation {
+	appCodec := encodingConfig.Marshaler
+
+	return []module.AppModuleSimulation{
+		auth.NewAppModule(appCodec, app.AccountKeeper, authsims.RandomGenesisAccounts),
+		bank.NewAppModule(appCodec, app.BankKeeper, app.AccountKeeper),
+		capability.NewAppModule(appCodec, *app.CapabilityKeeper),
+		gov.NewAppModule(appCodec, app.GovKeeper, app.AccountKeeper, app.BankKeeper),
+		mint.NewAppModule(appCodec, app.MintKeeper, app.AccountKeeper),
+		tax.NewAppModule(appCodec, app.TaxKeeper, app.AccountKeeper, app.BankKeeper),
+		staking.NewAppModule(appCodec, app.StakingKeeper, app.AccountKeeper, app.BankKeeper),
+		distribution.NewAppModule(appCodec, app.DistrKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
+		slashing.NewAppModule(appCodec, app.SlashingKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
+		params.NewAppModule(app.ParamsKeeper),
+		evidence.NewAppModule(app.EvidenceKeeper),
+		wasm.NewAppModule(
+			appCodec, &app.WasmKeeper,
+			app.AccountKeeper, app.BankKeeper,
+		),
+		ibc.NewAppModule(app.IBCKeeper),
+		app.AppKeepers.TransferModule,
+		app.AppKeepers.InterchainQueriesModule,
+		app.AppKeepers.InterchainTxsModule,
+	}
+}
+
+/*
+orderBeginBlockers tells the app's module manager how to set the order of
+BeginBlockers, which are run at the beginning of every block.
+
+Interchain Security Requirements:
+During begin block slashing happens after distr.BeginBlocker so that
+there is nothing left over in the validator fee pool, so as to keep the
+CanWithdrawInvariant invariant.
+NOTE: staking module is required if HistoricalEntries param > 0
+NOTE: capability module's beginblocker must come before any modules using capabilities (e.g. IBC)
+*/
+
+func orderBeginBlockers() []string {
+	return []string{
+		// upgrades should be run first
+		upgradetypes.ModuleName,
+		capabilitytypes.ModuleName,
+		minttypes.ModuleName,
+		distrtypes.ModuleName,
+		slashingtypes.ModuleName,
+		evidencetypes.ModuleName,
+		stakingtypes.ModuleName,
+		ibchost.ModuleName,
+		genutiltypes.ModuleName,
+		banktypes.ModuleName,
+		vestingtypes.ModuleName,
+		authtypes.ModuleName,
+		paramstypes.ModuleName,
+		ibctransfertypes.ModuleName,
+		crisistypes.ModuleName,
+		taxmoduletypes.ModuleName,
+		govtypes.ModuleName,
+		icatypes.ModuleName,
+		interchaintxstypes.ModuleName,
+		interchainqueriestypes.ModuleName,
+		contractmanagermoduletypes.ModuleName,
+		wasm.ModuleName,
+		feetypes.ModuleName,
+	}
+}
+
+func orderEndBlockers() []string {
+	return []string{
+		crisistypes.ModuleName,
+		govtypes.ModuleName,
+		stakingtypes.ModuleName,
+		ibchost.ModuleName,
+		paramstypes.ModuleName,
+		slashingtypes.ModuleName,
+		upgradetypes.ModuleName,
+		authtypes.ModuleName,
+		capabilitytypes.ModuleName,
+		vestingtypes.ModuleName,
+		minttypes.ModuleName,
+		evidencetypes.ModuleName,
+		ibctransfertypes.ModuleName,
+		genutiltypes.ModuleName,
+		banktypes.ModuleName,
+		distrtypes.ModuleName,
+		taxmoduletypes.ModuleName,
+		icatypes.ModuleName,
+		interchaintxstypes.ModuleName,
+		interchainqueriestypes.ModuleName,
+		contractmanagermoduletypes.ModuleName,
+		wasm.ModuleName,
+		feetypes.ModuleName,
+	}
+}
+
+/*
+NOTE: The genutils module must occur after staking so that pools are
+properly initialized with tokens from genesis accounts.
+NOTE: The genutils module must also occur after auth so that it can access the params from auth.
+NOTE: Capability module must occur first so that it can initialize any capabilities
+so that other modules that want to create or claim capabilities afterwards in InitChain
+can do so safely.
+*/
+func orderInitBlockers() []string {
+	return []string{
+		capabilitytypes.ModuleName,
+		authtypes.ModuleName,
+		banktypes.ModuleName,
+		distrtypes.ModuleName,
+		stakingtypes.ModuleName,
+		vestingtypes.ModuleName,
+		slashingtypes.ModuleName,
+		govtypes.ModuleName,
+		minttypes.ModuleName,
+		crisistypes.ModuleName,
+		taxmoduletypes.ModuleName,
+		ibchost.ModuleName,
+		genutiltypes.ModuleName,
+		evidencetypes.ModuleName,
+		paramstypes.ModuleName,
+		upgradetypes.ModuleName,
+		ibctransfertypes.ModuleName,
+		icatypes.ModuleName,
+		interchainqueriestypes.ModuleName,
+		interchaintxstypes.ModuleName,
+		contractmanagermoduletypes.ModuleName,
+		// wasm after ibc transfer
+		wasm.ModuleName,
+		feetypes.ModuleName,
+	}
+}

--- a/app/sim_test.go
+++ b/app/sim_test.go
@@ -228,37 +228,39 @@ func TestAppImportExport(t *testing.T) {
 
 	t.Log("comparing stores...")
 
+	keys := nolusApp.(*App).AppKeepers.GetKVStoreKey()
+	newKeys := newNolusApp.(*App).AppKeepers.GetKVStoreKey()
 	storeKeysPrefixes := []StoreKeysPrefixes{
-		{nolusApp.(*App).keys[authtypes.StoreKey], newNolusApp.(*App).keys[authtypes.StoreKey], [][]byte{}},
+		{keys[authtypes.StoreKey], newKeys[authtypes.StoreKey], [][]byte{}},
 		{
-			nolusApp.(*App).keys[stakingtypes.StoreKey], newNolusApp.(*App).keys[stakingtypes.StoreKey],
+			keys[stakingtypes.StoreKey], newKeys[stakingtypes.StoreKey],
 			[][]byte{
 				stakingtypes.UnbondingQueueKey, stakingtypes.RedelegationQueueKey, stakingtypes.ValidatorQueueKey,
 				stakingtypes.HistoricalInfoKey, stakingtypes.UnbondingIdKey, stakingtypes.UnbondingIndexKey, stakingtypes.UnbondingTypeKey, stakingtypes.ValidatorUpdatesKey,
 			},
 		},
-		{nolusApp.(*App).keys[slashingtypes.StoreKey], newNolusApp.(*App).keys[slashingtypes.StoreKey], [][]byte{}},
-		{nolusApp.(*App).keys[minttypes.StoreKey], newNolusApp.(*App).keys[minttypes.StoreKey], [][]byte{}},
-		{nolusApp.(*App).keys[distrtypes.StoreKey], newNolusApp.(*App).keys[distrtypes.StoreKey], [][]byte{}},
-		{nolusApp.(*App).keys[banktypes.StoreKey], newNolusApp.(*App).keys[banktypes.StoreKey], [][]byte{banktypes.BalancesPrefix}},
-		{nolusApp.(*App).keys[paramstypes.StoreKey], newNolusApp.(*App).keys[paramstypes.StoreKey], [][]byte{}},
-		{nolusApp.(*App).keys[govtypes.StoreKey], newNolusApp.(*App).keys[govtypes.StoreKey], [][]byte{}},
-		{nolusApp.(*App).keys[evidencetypes.StoreKey], newNolusApp.(*App).keys[evidencetypes.StoreKey], [][]byte{}},
-		{nolusApp.(*App).keys[capabilitytypes.StoreKey], newNolusApp.(*App).keys[capabilitytypes.StoreKey], [][]byte{}},
-		{nolusApp.(*App).keys[ibchost.StoreKey], newNolusApp.(*App).keys[ibchost.StoreKey], [][]byte{}},
-		{nolusApp.(*App).keys[ibctransfertypes.StoreKey], newNolusApp.(*App).keys[ibctransfertypes.StoreKey], [][]byte{}},
-		{nolusApp.(*App).keys[feetypes.StoreKey], newNolusApp.(*App).keys[feetypes.StoreKey], [][]byte{}},
-		{nolusApp.(*App).keys[minttypes.StoreKey], newNolusApp.(*App).keys[minttypes.StoreKey], [][]byte{}},
-		{nolusApp.(*App).keys[taxmoduletypes.StoreKey], newNolusApp.(*App).keys[taxmoduletypes.StoreKey], [][]byte{}},
-		{nolusApp.(*App).keys[interchaintxstypes.StoreKey], newNolusApp.(*App).keys[interchaintxstypes.StoreKey], [][]byte{}},
-		{nolusApp.(*App).keys[contractmanagermoduletypes.StoreKey], newNolusApp.(*App).keys[contractmanagermoduletypes.StoreKey], [][]byte{}},
-		{nolusApp.(*App).keys[interchainqueriestypes.StoreKey], newNolusApp.(*App).keys[interchainqueriestypes.StoreKey], [][]byte{}},
-		{nolusApp.(*App).keys[icacontrollertypes.StoreKey], newNolusApp.(*App).keys[icacontrollertypes.StoreKey], [][]byte{}},
-		{nolusApp.(*App).keys[wasm.StoreKey], newNolusApp.(*App).keys[wasm.StoreKey], [][]byte{}},
+		{keys[slashingtypes.StoreKey], newKeys[slashingtypes.StoreKey], [][]byte{}},
+		{keys[minttypes.StoreKey], newKeys[minttypes.StoreKey], [][]byte{}},
+		{keys[distrtypes.StoreKey], newKeys[distrtypes.StoreKey], [][]byte{}},
+		{keys[banktypes.StoreKey], newKeys[banktypes.StoreKey], [][]byte{banktypes.BalancesPrefix}},
+		{keys[paramstypes.StoreKey], newKeys[paramstypes.StoreKey], [][]byte{}},
+		{keys[govtypes.StoreKey], newKeys[govtypes.StoreKey], [][]byte{}},
+		{keys[evidencetypes.StoreKey], newKeys[evidencetypes.StoreKey], [][]byte{}},
+		{keys[capabilitytypes.StoreKey], newKeys[capabilitytypes.StoreKey], [][]byte{}},
+		{keys[ibchost.StoreKey], newKeys[ibchost.StoreKey], [][]byte{}},
+		{keys[ibctransfertypes.StoreKey], newKeys[ibctransfertypes.StoreKey], [][]byte{}},
+		{keys[feetypes.StoreKey], newKeys[feetypes.StoreKey], [][]byte{}},
+		{keys[minttypes.StoreKey], newKeys[minttypes.StoreKey], [][]byte{}},
+		{keys[taxmoduletypes.StoreKey], newKeys[taxmoduletypes.StoreKey], [][]byte{}},
+		{keys[interchaintxstypes.StoreKey], newKeys[interchaintxstypes.StoreKey], [][]byte{}},
+		{keys[contractmanagermoduletypes.StoreKey], newKeys[contractmanagermoduletypes.StoreKey], [][]byte{}},
+		{keys[interchainqueriestypes.StoreKey], newKeys[interchainqueriestypes.StoreKey], [][]byte{}},
+		{keys[icacontrollertypes.StoreKey], newKeys[icacontrollertypes.StoreKey], [][]byte{}},
+		{keys[wasm.StoreKey], newKeys[wasm.StoreKey], [][]byte{}},
 	}
 
 	// delete persistent tx counter value
-	ctxA.KVStore(nolusApp.(*App).keys[wasm.StoreKey]).Delete(wasmtypes.TXCounterPrefix)
+	ctxA.KVStore(keys[wasm.StoreKey]).Delete(wasmtypes.TXCounterPrefix)
 
 	// reset contract code index in source DB for comparison with dest DB
 	dropContractHistory := func(s store.KVStore, keys ...[]byte) {
@@ -272,8 +274,8 @@ func TestAppImportExport(t *testing.T) {
 		}
 	}
 	prefixes := [][]byte{wasmtypes.ContractCodeHistoryElementPrefix, wasmtypes.ContractByCodeIDAndCreatedSecondaryIndexPrefix}
-	dropContractHistory(ctxA.KVStore(nolusApp.(*App).keys[wasm.StoreKey]), prefixes...)
-	dropContractHistory(ctxB.KVStore(newNolusApp.(*App).keys[wasm.StoreKey]), prefixes...)
+	dropContractHistory(ctxA.KVStore(keys[wasm.StoreKey]), prefixes...)
+	dropContractHistory(ctxB.KVStore(newKeys[wasm.StoreKey]), prefixes...)
 
 	normalizeContractInfo := func(ctx sdk.Context, nApp *App) {
 		var index uint64
@@ -283,7 +285,7 @@ func TestAppImportExport(t *testing.T) {
 				TxIndex:     index,
 			}
 			info.Created = created
-			store := ctx.KVStore(nApp.keys[wasm.StoreKey])
+			store := ctx.KVStore(nApp.AppKeepers.GetKVStoreKey()[wasm.StoreKey])
 			store.Set(wasmtypes.GetContractAddressKey(address), nApp.appCodec.MustMarshal(&info))
 			index++
 			return false


### PR DESCRIPTION
Shortened app.go from 1000+ lines to ~300-400.
