### PR TITLE
docs: add per-module documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@
 **Nolus** is a blockchain built using Cosmos SDK and CometBFT.
 </div>
 
+## Repository layout
+
+The chain binary is `nolusd` (built from `cmd/`); app wiring lives in `app/`.
+The custom state-machine logic is in `x/` — each module has its own README:
+
+| Module | Purpose |
+|--------|---------|
+| [`x/mint`](x/mint/README.md) | Time-based NLS inflation (custom minting formula). |
+| [`x/tax`](x/tax/README.md) | Fees in foreign denoms + tax routed to treasury / DEX profit addresses. |
+| [`x/vestings`](x/vestings/README.md) | Create vesting accounts with a custom start time. |
+| [`x/interchaintxs`](x/interchaintxs/README.md) | Interchain Accounts (ICA) controller for contracts. |
+| [`x/transfer`](x/transfer/README.md) | IBC transfer with contract sudo callbacks. |
+| [`x/feerefunder`](x/feerefunder/README.md) | Escrow / refund of IBC relayer fees. |
+| [`x/contractmanager`](x/contractmanager/README.md) | Gas-limited contract sudo callbacks + failure recording. |
+
+Architecture decisions are recorded as ADRs under [`doc/adr/`](doc/adr/index.md).
+
 ## Prerequisites
 
 Install [golang](https://golang.org/), [tomlq](https://tomlq.readthedocs.io/en/latest/installation.html) and [jq](https://stedolan.github.io/jq/).
@@ -76,7 +93,7 @@ On a live network, a new DEX can be deployed using the following steps.
 
 * start hermes
 
-### Аutomated step
+### Automated step
 
 ```sh
 ./scripts/add-new-dex.sh --wasm-artifacts-path <wasm_artifacts_dir_path> --dex-name <dex_name> --dex-chain-id <new_dex_chain_id> --dex-ip-addr-rpc-host <new_dex_ip_addr_rpc_host_part> --dex-ip-addr-grpc-host <new_dex_ip_addr_grpc_host_part> --dex-account-prefix <new_dex_account_prefix> --dex-gas-price-denom <new_dex_price_denom> --dex-trusting-period-secs <new_dex_trusting_period_in_seconds>  --protocol-currency <new_protocol_currency> --protocol-swap-tree <new_protocol_swap_tree> --dex-network <dex_network_name> --dex-type-and-params '<dex_specific_field>'
@@ -97,7 +114,7 @@ The script takes care of setting up Hermes to work with the new DEX and, for now
 By default, `make build` generates a dynamically linked binary. In case someone would like to reproduce the way the binary is built in the pipeline then the command to achieve it locally is:
 
 ```sh
-docker run --rm -it -v "$(pwd)":/code public.ecr.aws/nolus/builder:<replace_with_the latest_tag> make build -C /code
+docker run --rm -it -v "$(pwd)":/code public.ecr.aws/nolus/builder:<replace_with_the_latest_tag> make build -C /code
 ```
 
 ## Upgrade wasmvm

--- a/x/contractmanager/README.md
+++ b/x/contractmanager/README.md
@@ -1,0 +1,37 @@
+# x/contractmanager
+
+Hardens the sudo callbacks that CosmWasm contracts receive for IBC events
+(acknowledgements and timeouts). Two responsibilities:
+
+1. **Gas-limited sudo** — wraps each sudo call in a configurable gas limit
+   (`sudo_call_gas_limit`) so a misbehaving or expensive contract callback cannot
+   exhaust block gas or halt packet processing (`ibc_middleware.go`).
+2. **Failure recording** — if a sudo callback errors or runs out of gas, the
+   failure is persisted as a `Failure` instead of reverting the IBC flow. The
+   contract can later query and resubmit it.
+
+Originally a Neutron module, internalized into nolus-core; see
+[ADR 20241025](../../doc/adr/20241025-decouple-and-minting-formula.md).
+
+## State
+
+`Failure` — `{ address, id, sudo_payload, error }`, keyed per contract address.
+
+## Queries
+
+| Query             | Returns                                   |
+|-------------------|-------------------------------------------|
+| `Failures`        | All recorded failures.                    |
+| `AddressFailures` | Failures for one contract address.        |
+| `AddressFailure`  | A single failure by `(address, id)`.      |
+
+## Params
+
+- `sudo_call_gas_limit` — gas ceiling applied to each contract sudo callback.
+
+## Wiring
+
+Installed as IBC middleware; `MsgUpdateParams` is governance-only. The error path
+is invoked by the IBC stack used by
+[`x/interchaintxs`](../interchaintxs/README.md) and
+[`x/transfer`](../transfer/README.md).

--- a/x/feerefunder/README.md
+++ b/x/feerefunder/README.md
@@ -1,0 +1,29 @@
+# x/feerefunder
+
+Escrows the IBC relayer fees that back asynchronous interchain operations
+(ICA / IBC transfers). When a contract sends an interchain packet it locks a
+`Fee` up front; once the packet resolves, the matching portion is paid to the
+relayer and any unused portion is refunded.
+
+Originally a Neutron module, internalized into nolus-core; see
+[ADR 20241025](../../doc/adr/20241025-decouple-and-minting-formula.md).
+
+## Concepts
+
+- **`Fee`** — three coin buckets per packet: `recv_fee`, `ack_fee`, `timeout_fee`.
+- **`PacketID`** — `(port_id, channel_id, sequence)` key the locked fee is stored under.
+
+## Keeper API (used by other modules)
+
+| Method                        | Effect                                                       |
+|-------------------------------|--------------------------------------------------------------|
+| `LockFees`                    | Escrow a payer's `Fee` for a packet before it is sent.       |
+| `DistributeAcknowledgementFee`| On ack: pay the relayer, refund the timeout bucket.          |
+| `DistributeTimeoutFee`        | On timeout: pay the relayer, refund the ack bucket.          |
+| `CheckFees`                   | Validate a `Fee` against module params before locking.       |
+
+## Wiring
+
+Called by [`x/interchaintxs`](../interchaintxs/README.md) and
+[`x/transfer`](../transfer/README.md) through their expected-keeper interfaces.
+`MsgUpdateParams` is governance-only.

--- a/x/interchaintxs/README.md
+++ b/x/interchaintxs/README.md
@@ -1,0 +1,29 @@
+# x/interchaintxs
+
+Interchain Accounts (ICA) controller module. It lets a Nolus account (typically a
+CosmWasm contract) register an interchain account on a remote chain over IBC and
+submit transactions to be executed there.
+
+Originally a Neutron module, internalized into nolus-core to allow direct
+modification (e.g. unordered ICA channels); see
+[ADR 20241025](../../doc/adr/20241025-decouple-and-minting-formula.md).
+
+## Messages
+
+| Message                        | Effect                                                                            |
+|--------------------------------|-----------------------------------------------------------------------------------|
+| `MsgRegisterInterchainAccount` | Open an ICA channel for `(owner, interchain_account_id)`; charges `register_fee`. |
+| `MsgSubmitTx`                  | Send `msgs` to the registered ICA over `connection_id` with a `timeout`.          |
+| `MsgUpdateParams`              | Governance: update `Params`.                                                      |
+
+## Params
+
+- `msg_submit_tx_max_messages` — upper bound on the number of messages a single
+  `MsgSubmitTx` may carry.
+
+## Wiring
+
+The keeper implements the IBC controller callbacks (`ibc_module.go`) and forwards
+packet lifecycle events to the registering contract. ICA fees are escrowed through
+[`x/feerefunder`](../feerefunder/README.md); IBC acknowledgement/timeout errors are
+recorded by [`x/contractmanager`](../contractmanager/README.md).

--- a/x/mint/README.md
+++ b/x/mint/README.md
@@ -1,0 +1,27 @@
+# x/mint
+
+Nolus-custom minting module. Replaces the Cosmos SDK `x/mint` with a time-based
+inflation schedule rather than a bonded-ratio target.
+
+New `unls` is minted in `BeginBlock` proportional to the time elapsed since the
+previous block, following a fixed minting formula (effective from month 17). The
+module was internalized — and the formula upgraded — as part of decoupling from
+external forks; see [ADR 20241025](../../doc/adr/20241025-decouple-and-minting-formula.md).
+
+## State
+
+- **`Minter`** — running mint state: `norm_time_passed`, `total_minted`,
+  `prev_block_timestamp`, `annual_inflation`.
+- **`Params`** — `mint_denom`, `max_mintable_nanoseconds` (caps the minted amount
+  for an abnormally long inter-block gap, e.g. after a halt).
+
+## Messages
+
+| Message          | Authority   | Effect                       |
+|------------------|-------------|------------------------------|
+| `MsgUpdateParams` | governance | Update `Params`.             |
+
+## Wiring
+
+`BeginBlocker` (`abci.go`) computes and mints the per-block amount and emits the
+`minted_tokens` OpenTelemetry counter. Params are governance-controlled.

--- a/x/tax/README.md
+++ b/x/tax/README.md
@@ -1,0 +1,34 @@
+# x/tax
+
+Nolus-custom fee module. It does two things at the ante-handler level:
+
+1. **Custom fee checker** (`CustomTxFeeChecker`) — lets transactions pay fees in
+   approved foreign denoms, not only the base denom (`unls`). Accepted denoms and
+   their minimum prices are governance parameters. See
+   [ADR 20250115](../../doc/adr/20250115-accept-fees-in-foreign-denoms.md).
+2. **Tax deduction** (`DeductTaxDecorator`) — takes `fee_rate` percent of the
+   collected transaction fee and routes it: base-denom fees go to the
+   `treasury_address`, foreign-denom fees go to the matching DEX `profit_address`.
+   The remainder stays as the validator fee.
+
+## Params
+
+| Field              | Type             | Meaning                                                        |
+|--------------------|------------------|----------------------------------------------------------------|
+| `fee_rate`         | `int32`          | Percent of the tx fee taken as tax (`0` disables deduction).   |
+| `base_denom`       | `string`         | Native fee denom (`unls`).                                     |
+| `treasury_address` | `string`         | Receives base-denom tax.                                       |
+| `dex_fee_params`   | `[]DexFeeParams` | Per-DEX profit address + accepted foreign denoms / min prices. |
+
+## Messages
+
+| Message           | Authority   | Effect           |
+|-------------------|-------------|------------------|
+| `MsgUpdateParams` | governance  | Update `Params`. |
+
+## Wiring
+
+Both decorators are installed in the ante chain (`app/ante.go`);
+`TaxKeeper.CustomTxFeeChecker` is passed to the SDK `DeductFeeDecorator` in
+`app/app.go`. `typesv2` holds the current params type; `migrations/` upgrades the
+v1beta1 params to v2.

--- a/x/transfer/README.md
+++ b/x/transfer/README.md
@@ -1,0 +1,25 @@
+# x/transfer
+
+A thin wrapper around the IBC `transfer` module that adds sudo callbacks so a
+CosmWasm contract initiating an IBC transfer is notified of the packet's outcome
+(acknowledgement / timeout), the same way [`x/interchaintxs`](../interchaintxs/README.md)
+reports ICA results.
+
+Originally a Neutron module, internalized into nolus-core; see
+[ADR 20241025](../../doc/adr/20241025-decouple-and-minting-formula.md).
+
+## Messages
+
+| Message           | Effect                                                                         |
+|-------------------|--------------------------------------------------------------------------------|
+| `MsgTransfer`     | Standard ICS-20 transfer that, on resolution, sudo-calls the sending contract. |
+| `MsgUpdateParams` | Governance: update the underlying IBC-transfer params.                         |
+
+`MsgTransferResponse` returns the `sequence_id` and `channel`, so the caller can
+correlate the later acknowledgement/timeout callback with the originating transfer.
+
+## Wiring
+
+`ibc_handlers.go` intercepts the IBC-transfer ack/timeout, escrows relayer fees via
+[`x/feerefunder`](../feerefunder/README.md), and routes failures to
+[`x/contractmanager`](../contractmanager/README.md).


### PR DESCRIPTION
## Summary
Documents the seven custom `x/` modules and gives the top-level README an orientation map. No code or behavior changes — documentation only.

## Motivation
Six of the seven custom modules had no README, and these `x/` modules are the part of the chain that isn't derivable from upstream Cosmos SDK docs.

## Changes
- **New module READMEs** for `x/mint`, `x/tax`, `x/interchaintxs`, `x/transfer`, `x/feerefunder`, and `x/contractmanager`. Each covers the module's purpose, its messages/params, and how it wires into the chain. Content is drawn from the proto contracts, keeper APIs, and existing ADRs.
- The four IBC-family modules are cross-linked (they call into one another at runtime), and each module points to its governing ADR rather than restating it — the README is the map, the ADR stays the source of truth.
- **README.md**: added a *Repository layout* table linking all seven modules (including the existing `x/vestings`);

## Verification
All relative links resolve to existing files. No code touched, so no build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
