### PR TITLE
feat: use the nolus ibc-go fork with the Solana light client

### DIFF
--- a/.github/actions/private-go-modules/action.yaml
+++ b/.github/actions/private-go-modules/action.yaml
@@ -1,0 +1,34 @@
+name: "Private Go modules"
+description:
+  "Points git and the go toolchain at the private nolus-protocol repository
+  serving Go modules. Must run after actions/checkout and before any go command."
+
+inputs:
+  token:
+    description: "Read-only token with access to the private repository"
+    required: true
+    default: ""
+
+  repository:
+    description: "Private nolus-protocol repository serving Go modules"
+    required: true
+    default: "ibc-go"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Point git and go at the private repository
+      shell: bash
+      env:
+        TOKEN: ${{ inputs.token }}
+        REPO: ${{ inputs.repository }}
+      run: |-
+        if [ -z "${TOKEN}" ]; then
+          echo "::error::token input is empty; check the secret exists and is visible to this repository"
+          exit 1
+        fi
+
+        git config --global \
+          url."https://x-access-token:${TOKEN}@github.com/nolus-protocol/${REPO}".insteadOf \
+          "https://github.com/nolus-protocol/${REPO}"
+        echo "GOPRIVATE=github.com/nolus-protocol/${REPO}" >> $GITHUB_ENV

--- a/.github/actions/private-go-modules/action.yaml
+++ b/.github/actions/private-go-modules/action.yaml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Point git and go at the private repository
-      shell: bash
+      shell: sh
       env:
         TOKEN: ${{ inputs.token }}
         REPO: ${{ inputs.repository }}

--- a/.github/workflows/nolus-core.yaml
+++ b/.github/workflows/nolus-core.yaml
@@ -255,7 +255,8 @@ jobs:
     if: github.ref_type == 'tag'
     runs-on: "ubuntu-latest"
     needs: add-meta
-    permissions: write-all
+    permissions:
+      contents: write
 
     steps:
       - name: Download artifacts

--- a/.github/workflows/nolus-core.yaml
+++ b/.github/workflows/nolus-core.yaml
@@ -103,6 +103,10 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - uses: "./.github/actions/private-go-modules"
+        with:
+          token: ${{ secrets.IBC_GO_TOKEN }}
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
@@ -126,6 +130,10 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - uses: "./.github/actions/private-go-modules"
+        with:
+          token: ${{ secrets.IBC_GO_TOKEN }}
+
       - run: |
           make test-unit
 
@@ -148,6 +156,10 @@ jobs:
           cache: false
 
       - uses: actions/checkout@v4
+
+      - uses: "./.github/actions/private-go-modules"
+        with:
+          token: ${{ secrets.IBC_GO_TOKEN }}
 
       - name: Download coverage result
         uses: actions/download-artifact@v8
@@ -182,6 +194,10 @@ jobs:
       - name: Set ownership
         run: |
           chown -R $(id -u):$(id -g) $PWD
+
+      - uses: "./.github/actions/private-go-modules"
+        with:
+          token: ${{ secrets.IBC_GO_TOKEN }}
 
       - name: Run build binary
         run: |

--- a/.github/workflows/test-cosmos.yaml
+++ b/.github/workflows/test-cosmos.yaml
@@ -20,6 +20,10 @@ jobs:
 
       - uses: actions/checkout@v3
 
+      - uses: "./.github/actions/private-go-modules"
+        with:
+          token: ${{ secrets.IBC_GO_TOKEN }}
+
       - name: Create a file with all core Cosmos SDK pkgs
         run: |
           go mod download
@@ -79,6 +83,11 @@ jobs:
         with:
           name: "${{ github.sha }}-${{ matrix.part }}"
 
+      - uses: "./.github/actions/private-go-modules"
+        if: env.GIT_DIFF
+        with:
+          token: ${{ secrets.IBC_GO_TOKEN }}
+
       - name: test
         if: env.GIT_DIFF
         run: |
@@ -104,6 +113,11 @@ jobs:
             **/go.sum
             **/Makefile
             Makefile
+
+      - uses: "./.github/actions/private-go-modules"
+        if: env.GIT_DIFF
+        with:
+          token: ${{ secrets.IBC_GO_TOKEN }}
 
       - name: test-sim-nondeterminism
         if: env.GIT_DIFF

--- a/.github/workflows/test-cosmos.yaml
+++ b/.github/workflows/test-cosmos.yaml
@@ -14,11 +14,11 @@ jobs:
   split-test-files:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.25
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: "./.github/actions/private-go-modules"
         with:
@@ -64,8 +64,8 @@ jobs:
         part: ["00", "01", "02", "03"]
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.25
 
@@ -97,10 +97,10 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 
+          go-version: 1.25
 
       - uses: technote-space/get-diff-action@v6.1.2
         id: git_diff

--- a/.github/workflows/test-fuzz.yaml
+++ b/.github/workflows/test-fuzz.yaml
@@ -14,6 +14,10 @@ jobs:
       
       - uses: actions/checkout@v3
 
+      - uses: "./.github/actions/private-go-modules"
+        with:
+          token: ${{ secrets.IBC_GO_TOKEN }}
+
       - run: |
           make test-sim-nondeterminism
 
@@ -26,6 +30,10 @@ jobs:
           go-version: 1.25
 
       - uses: actions/checkout@v3
-      
+
+      - uses: "./.github/actions/private-go-modules"
+        with:
+          token: ${{ secrets.IBC_GO_TOKEN }}
+
       - run: |
           make test-sim-import-export

--- a/.github/workflows/test-fuzz.yaml
+++ b/.github/workflows/test-fuzz.yaml
@@ -3,16 +3,19 @@ on:
   schedule:
     - cron: '0 3 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   nondeterminism:
     name: Test App State Determinism
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.25
       
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: "./.github/actions/private-go-modules"
         with:
@@ -25,11 +28,11 @@ jobs:
     name: Test App Import Export
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.25
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: "./.github/actions/private-go-modules"
         with:

--- a/go.mod
+++ b/go.mod
@@ -267,6 +267,9 @@ replace (
 	// explicitely replace iavl to v1.2.0 cause sometimes go mod tidy uses not right version
 	github.com/cosmos/iavl => github.com/cosmos/iavl v1.2.0
 
+	// ibc-go fork adds a Solana light client. The fork is a private repository, so building requires read access to it.
+	github.com/cosmos/ibc-go/v10 => github.com/nolus-protocol/ibc-go/v10 v10.5.0-nolus
+
 	// Fix upstream GHSA-h395-qcrw-5vmq vulnerability.
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.7.7

--- a/go.sum
+++ b/go.sum
@@ -248,8 +248,6 @@ github.com/cosmos/iavl v1.2.0 h1:kVxTmjTh4k0Dh1VNL046v6BXqKziqMDzxo93oh3kOfM=
 github.com/cosmos/iavl v1.2.0/go.mod h1:HidWWLVAtODJqFD6Hbne2Y0q3SdxByJepHUOeoH4LiI=
 github.com/cosmos/ibc-go/modules/capability v1.0.1 h1:ibwhrpJ3SftEEZRxCRkH0fQZ9svjthrX2+oXdZvzgGI=
 github.com/cosmos/ibc-go/modules/capability v1.0.1/go.mod h1:rquyOV262nGJplkumH+/LeYs04P3eV8oB7ZM4Ygqk4E=
-github.com/cosmos/ibc-go/v10 v10.5.0 h1:NI+cX04fXdu9JfP0V0GYeRi1ENa7PPdq0BYtVYo8Zrs=
-github.com/cosmos/ibc-go/v10 v10.5.0/go.mod h1:a74pAPUSJ7NewvmvELU74hUClJhwnmm5MGbEaiTw/kE=
 github.com/cosmos/ics23/go v0.11.0 h1:jk5skjT0TqX5e5QJbEnwXIS2yI2vnmLOgpQPeM5RtnU=
 github.com/cosmos/ics23/go v0.11.0/go.mod h1:A8OjxPE67hHST4Icw94hOxxFEJMBG031xIGF/JHNIY0=
 github.com/cosmos/keyring v1.2.0 h1:8C1lBP9xhImmIabyXW4c3vFjjLiBdGCmfLUfeZlV1Yo=
@@ -634,6 +632,8 @@ github.com/neutron-org/admin-module/v2 v2.0.0/go.mod h1:RfOyabXsdJ5btcOKyKPZDYiZ
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nolus-protocol/cosmos-sdk v0.53.3-nolus-3 h1:ckAPaI+Ampn3sxAzApfRsfVEK0MWmgg0tSNXY81vK2A=
 github.com/nolus-protocol/cosmos-sdk v0.53.3-nolus-3/go.mod h1:90S054hIbadFB1MlXVZVC5w0QbKfd1P4b79zT+vvJxw=
+github.com/nolus-protocol/ibc-go/v10 v10.5.0-nolus h1:W72fZUkP9257zxZEXMku0NTKtx6gJNV+4fyA1S8g85w=
+github.com/nolus-protocol/ibc-go/v10 v10.5.0-nolus/go.mod h1:a74pAPUSJ7NewvmvELU74hUClJhwnmm5MGbEaiTw/kE=
 github.com/nolus-protocol/wasmd v0.61.8-nolus h1:gcniW7VjjP/+wZgsuc2TFQoJy44UylmKYqE2ifQ1Ius=
 github.com/nolus-protocol/wasmd v0.61.8-nolus/go.mod h1:q1vBZkiZeCa8qDNe61IqFiKZxDLRG4uu9OEUVyj+2oo=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=


### PR DESCRIPTION
Switches ibc-go to the Nolus fork carrying the Solana light client, and gives CI the credential it needs to fetch it.

## The dependency

```
github.com/cosmos/ibc-go/v10 => github.com/nolus-protocol/ibc-go/v10 v10.5.0-nolus
```

The fork does not touch `go.mod`, so the dependency graph is unchanged — `go.sum` moves only the four ibc-go lines, and the `/go.mod` hash is byte-identical between upstream and the fork.

## Building now requires access to a private repository

This is the deliberate trade-off in this PR and it should be stated in the release notes:

- Validators cannot build the resulting binary from source without read access to `nolus-protocol/ibc-go`.
- `proxy.golang.org` will never hold a copy, so unlike the public `wasmd` and `cosmos-sdk` forks there is no cached fallback if the repository becomes unreachable. The repository and the `v10.5.0-nolus` tag are now a hard dependency of every future build, including rebuilds of past releases.

For anyone who does have access, building needs nothing beyond that access: a committed `go.sum` means the checksum database is never consulted. `GOPRIVATE=github.com/nolus-protocol/ibc-go` is only needed when adding or changing the fork's version with `go mod tidy` or `go get`.

## CI

New composite action `.github/actions/private-go-modules` rewrites the fork's clone URL to carry a token and sets `GOPRIVATE` for it. It runs in the nine jobs that invoke go; the protobuf and image jobs are untouched because they never resolve modules.

It requires the repository secret `IBC_GO_TOKEN` (already configured): a fine-grained token with resource owner `nolus-protocol`, repository access limited to `ibc-go`, and `Contents: Read-only`. The automatic `GITHUB_TOKEN` cannot be used — it is scoped to this repository, and the `permissions:` block grants scopes, never other repositories.

The step declares `shell: sh` rather than `bash`: the builder image is Alpine based and ships no bash. Sibling `run:` steps survive on the default shell, which falls back to `sh`, but an explicit `shell: bash` does not.

## Unrelated cleanup

Pre-existing issues found while touching these files, kept in a separate commit:

- `test-sim-nondeterminism` had an empty `go-version`, so it ran on whatever Go the runner shipped. Pinned to 1.25.
- `checkout@v3` and `setup-go@v4` bumped to v4 and v5 in the scheduled workflows.
- `test-fuzz` gained the read-only default `permissions` block the other two workflows already declare.
- `release` narrowed from `write-all` to the `contents: write` it needs to draft a release.

## Verification

- `go build ./...` clean against the fork, which matters because it touches `07-tendermint` client state, codec and update paths plus `02-client` params and `04-channel` expected keepers.
- `make test-unit`: 255 tests, 2 skipped, 0 failures.
- CI run `30531952609`: `golang-lint`, `test-unit` and `test-unit-coverage` all green while resolving the private module. `build-binary` failed there on the bash issue above and is fixed in this branch.

`Draft release` only runs on a tag, so the narrowed `contents: write` stays unexercised until the first tagged build.
