### PR TITLE
feat: add the v0.8.3 upgrade handler

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -68,6 +68,7 @@ import (
 	v080 "github.com/Nolus-Protocol/nolus-core/app/upgrades/v080"
 	v081 "github.com/Nolus-Protocol/nolus-core/app/upgrades/v081"
 	v082 "github.com/Nolus-Protocol/nolus-core/app/upgrades/v082"
+	v083 "github.com/Nolus-Protocol/nolus-core/app/upgrades/v083"
 	"github.com/Nolus-Protocol/nolus-core/docs"
 	"github.com/Nolus-Protocol/nolus-core/eip191"
 
@@ -87,6 +88,7 @@ var (
 		v04.Upgrade, v041.Upgrade, v042.Upgrade, v052.Upgrade, v053.Upgrade, v062.Upgrade,
 		v063.Upgrade, v064.Upgrade, v065.Upgrade, v066.Upgrade, v067.Upgrade, v068.Upgrade,
 		v069.Upgrade, v070.Upgrade, v072.Upgrade, v080.Upgrade, v081.Upgrade, v082.Upgrade,
+		v083.Upgrade,
 	}
 )
 

--- a/app/upgrades/v083/constants.go
+++ b/app/upgrades/v083/constants.go
@@ -1,0 +1,20 @@
+package v083
+
+import (
+	store "cosmossdk.io/store/types"
+	"github.com/Nolus-Protocol/nolus-core/app/upgrades"
+)
+
+const (
+	// UpgradeName defines the on-chain upgrades name.
+	UpgradeName = "v0.8.3"
+)
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades: store.StoreUpgrades{
+		Added:   []string{},
+		Deleted: []string{},
+	},
+}

--- a/app/upgrades/v083/upgrades.go
+++ b/app/upgrades/v083/upgrades.go
@@ -1,0 +1,33 @@
+package v083
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Nolus-Protocol/nolus-core/app/keepers"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+)
+
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	keepers *keepers.AppKeepers,
+	codec codec.Codec,
+) upgradetypes.UpgradeHandler {
+	return func(c context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		ctx := sdk.UnwrapSDKContext(c)
+
+		ctx.Logger().Info("Starting module migrations...")
+		vm, err := mm.RunMigrations(ctx, configurator, vm) //nolint:contextcheck
+		if err != nil {
+			return vm, err
+		}
+
+		ctx.Logger().Info(fmt.Sprintf("Migration {%s} applied", UpgradeName))
+		return vm, nil
+	}
+}


### PR DESCRIPTION
Registers the on-chain upgrade covering everything released after v0.8.2: dependency bumps (wasmd 0.61.8, wasmvm 3.0.3, cometbft 0.38.21, cosmos-sdk 0.53.5, ibc-go 10.5.0 via the nolus fork), Go 1.25, the contract-help command, and the mint and tax refactors.

No modules are added or removed and no store keys move, so StoreUpgrades is empty and the handler only runs module migrations.

The fork's new solana_allowed_relayers client param is left at its empty fail-closed default; a separate governance proposal will populate it.