### PR TITLE
fix: migrate x/wasm ContractInfo off the wasmd v0.61.1 field numbering

### DIFF
--- a/app/upgrades/v083/upgrades.go
+++ b/app/upgrades/v083/upgrades.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Nolus-Protocol/nolus-core/app/keepers"
 
 	upgradetypes "cosmossdk.io/x/upgrade/types"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -21,8 +22,15 @@ func CreateUpgradeHandler(
 	return func(c context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
 		ctx := sdk.UnwrapSDKContext(c)
 
+		ctx.Logger().Info("Migrating x/wasm ContractInfo records off the wasmd v0.61.1 field numbering...")
+		rewritten, err := MigrateContractInfoIBC2PortID(ctx, keepers.GetKey(wasmtypes.StoreKey), codec)
+		if err != nil {
+			return vm, err
+		}
+		ctx.Logger().Info(fmt.Sprintf("Rewrote %d x/wasm ContractInfo records", rewritten))
+
 		ctx.Logger().Info("Starting module migrations...")
-		vm, err := mm.RunMigrations(ctx, configurator, vm) //nolint:contextcheck
+		vm, err = mm.RunMigrations(ctx, configurator, vm) //nolint:contextcheck
 		if err != nil {
 			return vm, err
 		}

--- a/app/upgrades/v083/wasm_contract_info.go
+++ b/app/upgrades/v083/wasm_contract_info.go
@@ -1,0 +1,179 @@
+package v083
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+
+	"cosmossdk.io/store/prefix"
+	storetypes "cosmossdk.io/store/types"
+	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// wasmd v0.61.1 numbered ContractInfo.ibc2_port_id 7 and pushed extension to 8.
+// v0.61.5 reverted that, restoring extension to 7 and giving ibc2_port_id 8.
+// Every ContractInfo written while the chain ran v0.61.1 therefore stores the port
+// id under the field number v0.61.8 decodes as extension, which fails to unmarshal.
+const (
+	legacyIBC2PortIDField = 7
+	ibc2PortIDField       = 8
+
+	protoWireVarint = 0
+	protoWire64Bit  = 1
+	protoWireBytes  = 2
+	protoWire32Bit  = 5
+)
+
+// MigrateContractInfoIBC2PortID rewrites every x/wasm ContractInfo record from the
+// field numbering wasmd v0.61.1 used to the numbering restored in v0.61.8, and returns
+// the number of records rewritten. Records last written before the chain ran v0.61.1
+// carry no field 7 at all and are left untouched.
+//
+// It must run before the module migrations, because anything that reads a contract
+// panics on the unmigrated encoding.
+func MigrateContractInfoIBC2PortID(ctx sdk.Context, wasmStoreKey storetypes.StoreKey, cdc codec.BinaryCodec) (int, error) {
+	if wasmStoreKey == nil {
+		return 0, errors.New("nil x/wasm store key")
+	}
+	contractStore := prefix.NewStore(ctx.KVStore(wasmStoreKey), wasmtypes.ContractKeyPrefix)
+
+	rewritten, err := collectRewrites(contractStore, cdc)
+	if err != nil {
+		return 0, err
+	}
+	for _, record := range rewritten {
+		contractStore.Set(record.key, record.value)
+	}
+	return len(rewritten), nil
+}
+
+type contractRecord struct {
+	key   []byte
+	value []byte
+}
+
+// collectRewrites buffers the rewritten records instead of writing them back during
+// iteration, which is undefined behaviour on a cached KVStore. The buffer is a slice
+// in iterator order rather than a map, so the writes stay deterministic across nodes.
+func collectRewrites(contractStore prefix.Store, cdc codec.BinaryCodec) (rewritten []contractRecord, err error) {
+	iter := contractStore.Iterator(nil, nil)
+	defer func() {
+		if closeErr := iter.Close(); closeErr != nil && err == nil {
+			rewritten, err = nil, closeErr
+		}
+	}()
+
+	for ; iter.Valid(); iter.Next() {
+		migrated, changed, err := migrateContractInfoBz(iter.Value())
+		if err != nil {
+			return nil, fmt.Errorf("contract %X: %w", iter.Key(), err)
+		}
+		if !changed {
+			continue
+		}
+
+		var contractInfo wasmtypes.ContractInfo
+		if err := cdc.Unmarshal(migrated, &contractInfo); err != nil {
+			return nil, fmt.Errorf("contract %X: migrated record does not decode: %w", iter.Key(), err)
+		}
+		if contractInfo.IBC2PortID == "" {
+			return nil, fmt.Errorf("contract %X: migrated record lost its IBC v2 port id", iter.Key())
+		}
+
+		rewritten = append(rewritten, contractRecord{key: bytes.Clone(iter.Key()), value: migrated})
+	}
+	return rewritten, nil
+}
+
+// migrateContractInfoBz moves an ibc2_port_id stored under field 7 to field 8. Both
+// tags are a single byte of the same wire type, so the payload and the field ordering
+// are untouched and the result is byte-identical to what v0.61.8 encodes natively.
+func migrateContractInfoBz(bz []byte) ([]byte, bool, error) {
+	var out []byte
+	sawField8 := false
+
+	for i := 0; i < len(bz); {
+		tagStart := i
+		tag, tagLen := binary.Uvarint(bz[i:])
+		if tagLen <= 0 {
+			return nil, false, fmt.Errorf("malformed field tag at offset %d", i)
+		}
+		i += tagLen
+
+		fieldNum := tag >> 3
+		wireType := tag & 0x7
+
+		size, err := payloadSize(bz[i:], wireType)
+		if err != nil {
+			return nil, false, fmt.Errorf("field %d: %w", fieldNum, err)
+		}
+		if i+size > len(bz) {
+			return nil, false, fmt.Errorf("field %d: payload runs past end of record", fieldNum)
+		}
+
+		if fieldNum == ibc2PortIDField {
+			sawField8 = true
+		}
+
+		if fieldNum == legacyIBC2PortIDField {
+			if wireType != protoWireBytes {
+				return nil, false, fmt.Errorf("field %d has wire type %d, want %d", fieldNum, wireType, protoWireBytes)
+			}
+			if tagLen != 1 {
+				return nil, false, fmt.Errorf("field %d has a %d-byte tag, want 1", fieldNum, tagLen)
+			}
+
+			valueLen, lenLen := binary.Uvarint(bz[i:])
+			value := bz[i+lenLen : i+lenLen+int(valueLen)]
+			if !bytes.HasPrefix(value, []byte(wasmkeeper.PortIDPrefixV2)) {
+				return nil, false, fmt.Errorf("field %d holds %q, which is not an IBC v2 port id", fieldNum, value)
+			}
+
+			if out == nil {
+				out = bytes.Clone(bz)
+			}
+			out[tagStart] = byte(ibc2PortIDField<<3 | protoWireBytes)
+		}
+
+		i += size
+	}
+
+	if out != nil && sawField8 {
+		return nil, false, fmt.Errorf(
+			"record carries both field %d and field %d; rewriting would collide two values onto field %d",
+			legacyIBC2PortIDField, ibc2PortIDField, ibc2PortIDField)
+	}
+
+	return out, out != nil, nil
+}
+
+func payloadSize(bz []byte, wireType uint64) (int, error) {
+	switch wireType {
+	case protoWireVarint:
+		_, n := binary.Uvarint(bz)
+		if n <= 0 {
+			return 0, errors.New("malformed varint")
+		}
+		return n, nil
+	case protoWire64Bit:
+		return 8, nil
+	case protoWireBytes:
+		length, n := binary.Uvarint(bz)
+		if n <= 0 {
+			return 0, errors.New("malformed length prefix")
+		}
+		if length > math.MaxInt32 {
+			return 0, fmt.Errorf("length prefix %d out of range", length)
+		}
+		return n + int(length), nil
+	case protoWire32Bit:
+		return 4, nil
+	default:
+		return 0, fmt.Errorf("unsupported wire type %d", wireType)
+	}
+}

--- a/app/upgrades/v083/wasm_contract_info_test.go
+++ b/app/upgrades/v083/wasm_contract_info_test.go
@@ -1,0 +1,264 @@
+package v083_test
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storetypes "cosmossdk.io/store/types"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
+	"github.com/cosmos/gogoproto/proto"
+
+	v083 "github.com/Nolus-Protocol/nolus-core/app/upgrades/v083"
+)
+
+// The leaser contract as queried from mainnet while the chain ran wasmd v0.61.1.
+const (
+	leaserAddr    = "nolus1wn625s4jcmvk0szpl85rj5azkfc6suyvf75q6vrddscjdphtve8s5gg42f"
+	leaserAdmin   = "nolus1gurgpv8savnfw66lckwzn4zk7fp394lpe667dhu7aw48u40lj6jsqxf8nd"
+	leaserIBC2Prt = "wasm21wn625s4jcmvk0szpl85rj5azkfc6suyvf75q6vrddscjdphtve8s5gg42f"
+)
+
+func mainnetLeaser() wasmtypes.ContractInfo {
+	return wasmtypes.ContractInfo{
+		CodeID:     906,
+		Creator:    leaserAdmin,
+		Admin:      leaserAdmin,
+		Label:      "leaser",
+		Created:    &wasmtypes.AbsoluteTxPosition{BlockHeight: 0, TxIndex: 5830874},
+		IBCPortID:  "",
+		IBC2PortID: leaserIBC2Prt,
+	}
+}
+
+// encodeLegacy encodes a ContractInfo the way wasmd v0.61.1 did, with ibc2_port_id
+// under field 7. Field order matches gogoproto's ascending output.
+func encodeLegacy(t *testing.T, info wasmtypes.ContractInfo) []byte {
+	t.Helper()
+	require.Nil(t, info.Extension, "v0.61.1 stored extension at field 8; fixtures never set it")
+
+	var bz []byte
+	appendTag := func(field, wireType int) {
+		bz = binary.AppendUvarint(bz, uint64(field)<<3|uint64(wireType))
+	}
+	appendString := func(field int, s string) {
+		if s == "" {
+			return
+		}
+		appendTag(field, 2)
+		bz = binary.AppendUvarint(bz, uint64(len(s)))
+		bz = append(bz, s...)
+	}
+
+	if info.CodeID != 0 {
+		appendTag(1, 0)
+		bz = binary.AppendUvarint(bz, info.CodeID)
+	}
+	appendString(2, info.Creator)
+	appendString(3, info.Admin)
+	appendString(4, info.Label)
+	if info.Created != nil {
+		nested, err := proto.Marshal(info.Created)
+		require.NoError(t, err)
+		appendTag(5, 2)
+		bz = binary.AppendUvarint(bz, uint64(len(nested)))
+		bz = append(bz, nested...)
+	}
+	appendString(6, info.IBCPortID)
+	appendString(legacyIBC2PortIDField, info.IBC2PortID)
+
+	return bz
+}
+
+const (
+	legacyIBC2PortIDField = 7
+	ibc2PortIDField       = 8
+)
+
+func TestMigrateContractInfo_MainnetLeaser(t *testing.T) {
+	expected := mainnetLeaser()
+	legacy := encodeLegacy(t, expected)
+
+	var beforeMigration wasmtypes.ContractInfo
+	require.Error(t, proto.Unmarshal(legacy, &beforeMigration),
+		"the v0.61.1 encoding must be undecodable by v0.61.8, otherwise there is nothing to migrate")
+
+	migrated := migrateOne(t, legacy)
+
+	var got wasmtypes.ContractInfo
+	require.NoError(t, proto.Unmarshal(migrated, &got))
+	require.Equal(t, expected, got)
+	require.Equal(t, leaserIBC2Prt, got.IBC2PortID)
+	require.Nil(t, got.Extension)
+
+	canonical, err := proto.Marshal(&expected)
+	require.NoError(t, err)
+	require.Equal(t, canonical, migrated,
+		"migrated bytes must be identical to what v0.61.8 writes natively")
+}
+
+func TestMigrateContractInfo_LeavesUntouchedRecordsAlone(t *testing.T) {
+	// A contract last written before the chain ran v0.61.1 carries no field 7.
+	preUpgrade := wasmtypes.ContractInfo{
+		CodeID:  12,
+		Creator: leaserAdmin,
+		Label:   "lpp",
+		Created: &wasmtypes.AbsoluteTxPosition{BlockHeight: 4200000, TxIndex: 3},
+	}
+	legacy := encodeLegacy(t, preUpgrade)
+
+	ctx, storeKey, cdc := setupWasmStore(t)
+	contractStore := ctx.KVStore(storeKey)
+	key := wasmtypes.GetContractAddressKey([]byte("pre-upgrade-contract"))
+	contractStore.Set(key, legacy)
+
+	rewritten, err := v083.MigrateContractInfoIBC2PortID(ctx, storeKey, cdc)
+	require.NoError(t, err)
+	require.Equal(t, 0, rewritten)
+	require.Equal(t, legacy, contractStore.Get(key), "record must be byte-for-byte unchanged")
+
+	var got wasmtypes.ContractInfo
+	require.NoError(t, cdc.Unmarshal(contractStore.Get(key), &got))
+	require.Equal(t, preUpgrade, got)
+}
+
+func TestMigrateContractInfo_AlreadyMigratedIsNoOp(t *testing.T) {
+	info := mainnetLeaser()
+	upstream, err := proto.Marshal(&info)
+	require.NoError(t, err)
+
+	ctx, storeKey, cdc := setupWasmStore(t)
+	contractStore := ctx.KVStore(storeKey)
+	key := wasmtypes.GetContractAddressKey([]byte("already-migrated"))
+	contractStore.Set(key, upstream)
+
+	rewritten, err := v083.MigrateContractInfoIBC2PortID(ctx, storeKey, cdc)
+	require.NoError(t, err)
+	require.Equal(t, 0, rewritten)
+	require.Equal(t, upstream, contractStore.Get(key))
+}
+
+func TestMigrateContractInfo_MixedStore(t *testing.T) {
+	ctx, storeKey, cdc := setupWasmStore(t)
+	contractStore := ctx.KVStore(storeKey)
+
+	leaser := mainnetLeaser()
+	lease := wasmtypes.ContractInfo{
+		CodeID:     907,
+		Creator:    leaserAddr,
+		Admin:      leaserAddr,
+		Label:      "lease",
+		Created:    &wasmtypes.AbsoluteTxPosition{BlockHeight: 0, TxIndex: 5830900},
+		IBC2PortID: "wasm21qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq",
+	}
+	preUpgrade := wasmtypes.ContractInfo{
+		CodeID:  12,
+		Creator: leaserAdmin,
+		Label:   "oracle",
+		Created: &wasmtypes.AbsoluteTxPosition{BlockHeight: 4200000, TxIndex: 3},
+	}
+
+	keys := map[string]wasmtypes.ContractInfo{
+		"leaser":     leaser,
+		"lease":      lease,
+		"preUpgrade": preUpgrade,
+	}
+	for name, info := range keys {
+		contractStore.Set(wasmtypes.GetContractAddressKey([]byte(name)), encodeLegacy(t, info))
+	}
+
+	rewritten, err := v083.MigrateContractInfoIBC2PortID(ctx, storeKey, cdc)
+	require.NoError(t, err)
+	require.Equal(t, 2, rewritten, "only the two records carrying an ibc2 port id are rewritten")
+
+	for name, expected := range keys {
+		var got wasmtypes.ContractInfo
+		require.NoError(t, cdc.Unmarshal(contractStore.Get(wasmtypes.GetContractAddressKey([]byte(name))), &got), name)
+		require.Equal(t, expected, got, name)
+	}
+}
+
+func TestMigrateContractInfo_RejectsNonPortPayloadAtField7(t *testing.T) {
+	// A genuine Extension would also sit at field 7. Nolus has never set one, so
+	// rather than silently reinterpreting it as a port id the upgrade must abort.
+	extension, err := proto.Marshal(&wasmtypes.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 2})
+	require.NoError(t, err)
+
+	var bz []byte
+	bz = binary.AppendUvarint(bz, 1<<3|0)
+	bz = binary.AppendUvarint(bz, 906)
+	bz = binary.AppendUvarint(bz, legacyIBC2PortIDField<<3|2)
+	bz = binary.AppendUvarint(bz, uint64(len(extension)))
+	bz = append(bz, extension...)
+
+	ctx, storeKey, cdc := setupWasmStore(t)
+	ctx.KVStore(storeKey).Set(wasmtypes.GetContractAddressKey([]byte("has-extension")), bz)
+
+	_, err = v083.MigrateContractInfoIBC2PortID(ctx, storeKey, cdc)
+	require.ErrorContains(t, err, "not an IBC v2 port id")
+}
+
+func TestMigrateContractInfo_RejectsRecordCarryingBothFields(t *testing.T) {
+	// v0.61.1 stored extension at field 8. Nolus never set one, but if a record did
+	// carry both, moving field 7 onto field 8 would silently drop one of the values.
+	extension, err := proto.Marshal(&wasmtypes.AbsoluteTxPosition{BlockHeight: 1, TxIndex: 2})
+	require.NoError(t, err)
+
+	bz := encodeLegacy(t, mainnetLeaser())
+	bz = binary.AppendUvarint(bz, ibc2PortIDField<<3|2)
+	bz = binary.AppendUvarint(bz, uint64(len(extension)))
+	bz = append(bz, extension...)
+
+	ctx, storeKey, cdc := setupWasmStore(t)
+	ctx.KVStore(storeKey).Set(wasmtypes.GetContractAddressKey([]byte("both-fields")), bz)
+
+	_, err = v083.MigrateContractInfoIBC2PortID(ctx, storeKey, cdc)
+	require.ErrorContains(t, err, "would collide")
+}
+
+func TestMigrateContractInfo_RejectsMalformedRecord(t *testing.T) {
+	legacy := encodeLegacy(t, mainnetLeaser())
+
+	ctx, storeKey, cdc := setupWasmStore(t)
+	ctx.KVStore(storeKey).Set(wasmtypes.GetContractAddressKey([]byte("truncated")), legacy[:len(legacy)-4])
+
+	_, err := v083.MigrateContractInfoIBC2PortID(ctx, storeKey, cdc)
+	require.Error(t, err)
+}
+
+func TestMigrateContractInfo_NilStoreKey(t *testing.T) {
+	ctx, _, cdc := setupWasmStore(t)
+	_, err := v083.MigrateContractInfoIBC2PortID(ctx, nil, cdc)
+	require.ErrorContains(t, err, "nil x/wasm store key")
+}
+
+func migrateOne(t *testing.T, legacy []byte) []byte {
+	t.Helper()
+
+	ctx, storeKey, cdc := setupWasmStore(t)
+	contractStore := ctx.KVStore(storeKey)
+	key := wasmtypes.GetContractAddressKey([]byte("contract"))
+	contractStore.Set(key, legacy)
+
+	rewritten, err := v083.MigrateContractInfoIBC2PortID(ctx, storeKey, cdc)
+	require.NoError(t, err)
+	require.Equal(t, 1, rewritten)
+
+	return contractStore.Get(key)
+}
+
+func setupWasmStore(t *testing.T) (sdk.Context, *storetypes.KVStoreKey, codec.Codec) {
+	t.Helper()
+
+	storeKey := storetypes.NewKVStoreKey(wasmtypes.StoreKey)
+	tKey := storetypes.NewTransientStoreKey("transient_test")
+	ctx := testutil.DefaultContext(storeKey, tKey)
+	cdc := moduletestutil.MakeTestEncodingConfig().Codec
+
+	return ctx, storeKey, cdc
+}


### PR DESCRIPTION
## Problem

wasmd v0.61.1 numbered `ContractInfo.ibc2_port_id` 7 and pushed `extension` to 8. v0.61.5 reverted that in CosmWasm/wasmd#2390, restoring `extension` to 7 and giving `ibc2_port_id` 8.

Upstream classed this as **API** breaking and shipped no state migration, having retracted v0.61.0 through v0.61.4 on the assumption that no live chain had run them. Nolus ran v0.61.1 from v0.8.1 onwards.

| | `extension` | `ibc2_port_id` |
|---|---|---|
| wasmd ≤ 0.55 | field 7 | — |
| wasmd 0.61.1 | field 8 | field 7 |
| wasmd 0.61.5+ | field 7 | field 8 |

`keeper.InstantiateContract` sets `IBC2PortID` unconditionally, not only for contracts with IBC v2 entry points. So every contract instantiated, migrated, relabelled, or whose admin changed since the v0.8.1 upgrade stores its port id under field 7. v0.61.8 decodes field 7 as `extension` and fails with `proto: illegal wireType 7`, and `GetContractInfo` uses `MustUnmarshal` — so reading any such contract panics rather than erroring.

This is confirmed on both networks: querying a contract works against v0.61.1 and fails against v0.55.0 and v0.61.8.

The v0.55 to v0.61.1 jump caused no visible problem because Nolus has never populated `ContractInfo.Extension`. A nil `Any` is not emitted on the wire, so field 7 was simply absent from every record written before v0.8.1, and the renumbering had nothing to collide with. The break only surfaces on a binary that expects field 7 to be an `Any` again.

`ContractInfo` is the only state-affecting proto difference between the two versions.

## Change

`MigrateContractInfoIBC2PortID` iterates the x/wasm contract prefix and moves `ibc2_port_id` from field 7 to field 8. Both tags are a single byte of the same wire type, so the payload and the field ordering are untouched and the result is byte-identical to what v0.61.8 encodes natively. Records last written before the chain ran v0.61.1 carry no field 7 and are left untouched, so the mixed state is handled.

It runs in the v0.8.3 upgrade handler **ahead of** `RunMigrations`, because anything that reads a contract panics until it has run. Rewrites are buffered in a slice in iterator order and applied after iteration completes, rather than written back mid-iteration.

Since `ConsensusVersion` is 4 in both wasmd versions with an identical `Migrate3to4`, no wasmd module migration fires — this has to live in the chain's upgrade handler.

## Refusing to guess

Two conditions abort the upgrade rather than corrupt state silently:

- A field 7 payload that is not an IBC v2 port id. This is where a genuine `extension` would sit; Nolus has never set one, but reinterpreting it as a port id would be silent corruption.
- A record carrying both field 7 and field 8, where moving one onto the other would drop a value.

## Tests

Eight tests built around a real mainnet record (the leaser contract, `code_id: 906`), asserting that:

- the v0.61.1 encoding **fails** to decode under v0.61.8, so the migration is not a no-op
- the migrated record decodes to exactly the expected `ContractInfo`, port id intact
- the migrated bytes equal `proto.Marshal` of that struct
- untouched pre-v0.61.1 records come through byte-for-byte unchanged
- already-migrated records are a no-op
- a mixed store rewrites only the affected records
- both abort conditions are rejected

## Verification before the upgrade

Worth running against a testnet state export first. The handler logs the number of records rewritten, which can be sanity-checked against how many contracts are expected to have been touched since v0.8.1.

## Note for integrators

Unrelated to state, the same version bump moves a REST route: `/cosmwasm/wasm/v1/contract/build_address` becomes `/cosmwasm/wasm/v1/build_address`. Relevant to explorers and indexers.

