### PR TITLE
feat(upgrade): add v0.8.4 upgrade handler and bump ibc-go to v10.5.0-…

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -69,6 +69,7 @@ import (
 	v081 "github.com/Nolus-Protocol/nolus-core/app/upgrades/v081"
 	v082 "github.com/Nolus-Protocol/nolus-core/app/upgrades/v082"
 	v083 "github.com/Nolus-Protocol/nolus-core/app/upgrades/v083"
+	v084 "github.com/Nolus-Protocol/nolus-core/app/upgrades/v084"
 	"github.com/Nolus-Protocol/nolus-core/docs"
 	"github.com/Nolus-Protocol/nolus-core/eip191"
 
@@ -88,7 +89,7 @@ var (
 		v04.Upgrade, v041.Upgrade, v042.Upgrade, v052.Upgrade, v053.Upgrade, v062.Upgrade,
 		v063.Upgrade, v064.Upgrade, v065.Upgrade, v066.Upgrade, v067.Upgrade, v068.Upgrade,
 		v069.Upgrade, v070.Upgrade, v072.Upgrade, v080.Upgrade, v081.Upgrade, v082.Upgrade,
-		v083.Upgrade,
+		v083.Upgrade, v084.Upgrade,
 	}
 )
 

--- a/app/upgrades/v084/constants.go
+++ b/app/upgrades/v084/constants.go
@@ -1,0 +1,20 @@
+package v084
+
+import (
+	store "cosmossdk.io/store/types"
+	"github.com/Nolus-Protocol/nolus-core/app/upgrades"
+)
+
+const (
+	// UpgradeName defines the on-chain upgrades name.
+	UpgradeName = "v0.8.4"
+)
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades: store.StoreUpgrades{
+		Added:   []string{},
+		Deleted: []string{},
+	},
+}

--- a/app/upgrades/v084/upgrades.go
+++ b/app/upgrades/v084/upgrades.go
@@ -1,0 +1,39 @@
+package v084
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Nolus-Protocol/nolus-core/app/keepers"
+
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+)
+
+// CreateUpgradeHandler for v0.8.4 carries no state migration: the release is a
+// security patch to the ibc-go Solana light client (relayer-allowlist gating of
+// MsgSubmitMisbehaviour, the SolanaHeader client-type guard, and header slot and
+// timestamp bounds), all of which live in the binary and take effect the moment
+// the upgraded node runs. The handler exists so the software-upgrade plan named
+// "v0.8.4" resolves and the chain resumes on the patched binary.
+func CreateUpgradeHandler(
+	mm *module.Manager,
+	configurator module.Configurator,
+	_ *keepers.AppKeepers,
+	_ codec.Codec,
+) upgradetypes.UpgradeHandler {
+	return func(c context.Context, _ upgradetypes.Plan, vm module.VersionMap) (module.VersionMap, error) {
+		ctx := sdk.UnwrapSDKContext(c)
+
+		ctx.Logger().Info("Starting module migrations...")
+		vm, err := mm.RunMigrations(ctx, configurator, vm) //nolint:contextcheck
+		if err != nil {
+			return vm, err
+		}
+
+		ctx.Logger().Info(fmt.Sprintf("Migration {%s} applied", UpgradeName))
+		return vm, nil
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -268,7 +268,7 @@ replace (
 	github.com/cosmos/iavl => github.com/cosmos/iavl v1.2.0
 
 	// ibc-go fork adds a Solana light client. The fork is a private repository, so building requires read access to it.
-	github.com/cosmos/ibc-go/v10 => github.com/nolus-protocol/ibc-go/v10 v10.5.0-nolus
+	github.com/cosmos/ibc-go/v10 => github.com/nolus-protocol/ibc-go/v10 v10.5.0-nolus-1
 
 	// Fix upstream GHSA-h395-qcrw-5vmq vulnerability.
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409

--- a/go.sum
+++ b/go.sum
@@ -632,8 +632,8 @@ github.com/neutron-org/admin-module/v2 v2.0.0/go.mod h1:RfOyabXsdJ5btcOKyKPZDYiZ
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nolus-protocol/cosmos-sdk v0.53.3-nolus-3 h1:ckAPaI+Ampn3sxAzApfRsfVEK0MWmgg0tSNXY81vK2A=
 github.com/nolus-protocol/cosmos-sdk v0.53.3-nolus-3/go.mod h1:90S054hIbadFB1MlXVZVC5w0QbKfd1P4b79zT+vvJxw=
-github.com/nolus-protocol/ibc-go/v10 v10.5.0-nolus h1:W72fZUkP9257zxZEXMku0NTKtx6gJNV+4fyA1S8g85w=
-github.com/nolus-protocol/ibc-go/v10 v10.5.0-nolus/go.mod h1:a74pAPUSJ7NewvmvELU74hUClJhwnmm5MGbEaiTw/kE=
+github.com/nolus-protocol/ibc-go/v10 v10.5.0-nolus-1 h1:JOHHP2M6VbMbKcaYqJB9YZrOGxp0ND/zWicjt6e0R0M=
+github.com/nolus-protocol/ibc-go/v10 v10.5.0-nolus-1/go.mod h1:a74pAPUSJ7NewvmvELU74hUClJhwnmm5MGbEaiTw/kE=
 github.com/nolus-protocol/wasmd v0.61.8-nolus h1:gcniW7VjjP/+wZgsuc2TFQoJy44UylmKYqE2ifQ1Ius=
 github.com/nolus-protocol/wasmd v0.61.8-nolus/go.mod h1:q1vBZkiZeCa8qDNe61IqFiKZxDLRG4uu9OEUVyj+2oo=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=


### PR DESCRIPTION
…nolus-1

Bumps the ibc-go fork replace to v10.5.0-nolus-1 and registers the matching v0.8.4 upgrade handler.

The handler runs no state migration — the changes ship in the binary and take effect when the upgraded node runs. It exists so the software-upgrade plan named v0.8.4 resolves and the chain resumes on the new binary.