### PR TITLE
chore(config): lower recommended consensus timeouts to 2s

### DIFF
--- a/cmd/nolusd/root.go
+++ b/cmd/nolusd/root.go
@@ -122,12 +122,12 @@ var (
 		{
 			Section: "consensus",
 			Key:     "timeout_commit",
-			Value:   "2.5s",
+			Value:   "2s",
 		},
 		{
 			Section: "consensus",
 			Key:     "timeout_propose",
-			Value:   "2.5s",
+			Value:   "2s",
 		},
 		{
 			Section: "consensus",


### PR DESCRIPTION
## Summary

Lowers the recommended consensus timeouts that `nolusd` writes into every node's `config.toml` on startup:

| key | before | after |
|---|---|---|
| `timeout_commit` | 2.5s | 2s |
| `timeout_propose` | 2.5s | 2s |

## Why

Block time = `timeout_commit` (a fixed idle wait after +2/3 precommits) + the real consensus round time. Measured over 1000-block windows (2026-08-24):

- **pirin-1**: 2.99s average → ~0.49s of actual consensus gossip on top of the 2.5s wait
- **rila-3**: 2.53s average → ~0.03s on top

Expected after validators restart on a release carrying this change:

- **pirin-1**: ~2.5s blocks (≈17% faster)
- **rila-3**: ~2.05s blocks

`timeout_propose` does not contribute to happy-path block time (it is the deadline for skipping an offline proposer); lowering it to 2s shortens stalls on missed proposals and still leaves ~4x headroom over observed propagation.

## Safety and rollout

- These are per-node liveness knobs — they cannot fork or halt the chain, and mixed values during the validator rollout are safe: block time slides down as roughly two-thirds of stake restarts on the new version. No governance change is required for the timing itself.
- The `x/slashing` downtime window (`signed_blocks_window` = 10,000 blocks) shrinks in wall time from ~8.3h to ~6.9h at 2.5s blocks — modest; a proportional bump can wait for a bigger reduction step.
- First step of a staged reduction; Osmosis followed the same path (2.5s → … → 550ms) incrementally.

## After deploy, watch

- Per-validator missed-signature rates (absence from `LastCommit`)
- Frequency of consensus rounds > 0 (proposer misses)
- Node catch-up sync speed relative to the new block rate
