### PR TITLE
fix: replace dead help-center link in security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ Covers the Nolus blockchain, smart contracts, and webapp. The bounty program foc
 - Unauthorized access to restricted pages
 - Deletion or tampering with user data
 
-Program details: https://hub.nolus.io/en/articles/9680739-security
+Audit reports and the full policy: https://docs.nolus.io/docs/protocol/security
 
 ## What to include in your report
 


### PR DESCRIPTION
The help-center article this line pointed to (hub.nolus.io article 9680739, Security) was deleted on 2026-08-04, so the link returned a 404. Point readers to the security page on docs.nolus.io instead; it carries the audit reports and the same reporting policy.